### PR TITLE
Fix Render deploy: dynamic port, DB guard, keep-alive ping

### DIFF
--- a/app.js
+++ b/app.js
@@ -39,9 +39,35 @@ const app = express();
 /**
  * *Defining port number and mongoUrl
  */
-const port = 8080;
+const port = process.env.PORT || 8080;
 const dbUrl = process.env.ATLASDB_URL;
 //const dbUrl = "mongodb://localhost:27017/eanderlust";
+
+if (!dbUrl) {
+  console.error(
+    "FATAL: ATLASDB_URL is not set. Configure it in your Render environment variables."
+  );
+  process.exit(1);
+}
+
+/**
+ * * Self-ping (keep-alive) so Render's free instance does not sleep.
+ * ? Pings SELF_URL every 3 minutes when running in production.
+ */
+const SELF_URL =
+  process.env.SELF_URL || "https://wanderlust-1-88ni.onrender.com";
+if (process.env.NODE_ENV === "production") {
+  setInterval(() => {
+    const https = require("https");
+    https
+      .get(SELF_URL, (res) => {
+        console.log(`[keep-alive] ${SELF_URL} -> ${res.statusCode}`);
+      })
+      .on("error", (err) => {
+        console.log(`[keep-alive] error: ${err.message}`);
+      });
+  }, 3 * 60 * 1000);
+}
 
 /**
  * * Set up view engine, directory for views, static files, body parsing, and method override middleware
@@ -138,7 +164,14 @@ app.use("/filter", filterRouter);
  * * Starting Express Server
  */
 app.listen(port, () => {
-  console.log("Started Listening!!!");
+  console.log(`Started Listening on port ${port}!!!`);
+});
+
+/**
+ * * Health-check endpoint used by the self-ping keep-alive and Render health checks.
+ */
+app.get("/health", (req, res) => {
+  res.status(200).json({ status: "ok", uptime: process.uptime() });
 });
 
 app.get("/privacy", (req, res) => {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
+    "start": "node app.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],


### PR DESCRIPTION
## Summary
- Use \`process.env.PORT\` so Render's assigned port is honored (was hardcoded to 8080, root cause of the deploy failing silently after Mongo errored)
- Fail fast with a clear message if \`ATLASDB_URL\` is unset instead of falling back to \`localhost:27017\` (this caused the \`ECONNREFUSED 127.0.0.1:27017\` in the live logs)
- Self-ping \`SELF_URL\` every 3 minutes in production to prevent Render free-tier sleep
- Add \`/health\` endpoint for the keep-alive and Render health checks
- Add \`npm start\` script

## Required Render env vars
- \`ATLASDB_URL\` — MongoDB Atlas connection string
- \`SECRET\` — session secret
- \`NODE_ENV=production\`
- \`CLOUD_NAME\`, \`CLOUD_API_KEY\`, \`CLOUD_API_SECRET\` (Cloudinary)
- \`SELF_URL\` (optional) — defaults to https://wanderlust-1-88ni.onrender.com

## Test plan
- [ ] Deploy to Render with all env vars set; confirm app boots and \`/health\` returns 200
- [ ] Confirm logs show \`[keep-alive] ... -> 200\` every 3 minutes
- [ ] Hit live URL after 30 minutes idle; site responds without cold-start delay