### PR TITLE
UI: non-blocking toast notifications (replaces flash alerts)

### DIFF
--- a/public/JS/toast.js
+++ b/public/JS/toast.js
@@ -1,0 +1,87 @@
+(function () {
+  "use strict";
+
+  const DEFAULT_DURATION = 4000;
+
+  const ICONS = {
+    success: '<i class="fa-solid fa-check" aria-hidden="true"></i>',
+    error: '<i class="fa-solid fa-xmark" aria-hidden="true"></i>',
+    info: '<i class="fa-solid fa-bell" aria-hidden="true"></i>',
+  };
+
+  const ROLE = {
+    success: { role: "status", live: "polite" },
+    info: { role: "status", live: "polite" },
+    error: { role: "alert", live: "assertive" },
+  };
+
+  function ensureStack() {
+    let stack = document.querySelector(".toast-stack");
+    if (!stack) {
+      stack = document.createElement("div");
+      stack.className = "toast-stack";
+      stack.setAttribute("aria-live", "polite");
+      stack.setAttribute("aria-atomic", "false");
+      document.body.appendChild(stack);
+    }
+    return stack;
+  }
+
+  function dismiss(toast) {
+    if (!toast || toast.classList.contains("is-leaving")) return;
+    toast.classList.add("is-leaving");
+    toast.classList.remove("is-visible");
+    const cleanup = () => toast.remove();
+    toast.addEventListener("transitionend", cleanup, { once: true });
+    setTimeout(cleanup, 500);
+  }
+
+  function show(message, type = "info", duration = DEFAULT_DURATION) {
+    if (!message) return;
+    const stack = ensureStack();
+    const variant = ICONS[type] ? type : "info";
+    const meta = ROLE[variant];
+
+    const toast = document.createElement("div");
+    toast.className = `toast-item toast-item--${variant}`;
+    toast.setAttribute("role", meta.role);
+    toast.setAttribute("aria-live", meta.live);
+
+    toast.innerHTML = `
+      <span class="toast-item__icon">${ICONS[variant]}</span>
+      <div class="toast-item__body"></div>
+      <button type="button" class="toast-item__close" aria-label="Dismiss notification">
+        <i class="fa-solid fa-xmark" aria-hidden="true"></i>
+      </button>
+      <span class="toast-item__progress" style="animation-duration:${duration}ms"></span>
+    `;
+    toast.querySelector(".toast-item__body").textContent = message;
+    toast
+      .querySelector(".toast-item__close")
+      .addEventListener("click", () => dismiss(toast));
+
+    stack.appendChild(toast);
+    requestAnimationFrame(() => toast.classList.add("is-visible"));
+
+    const timer = setTimeout(() => dismiss(toast), duration);
+    toast.addEventListener("mouseenter", () => clearTimeout(timer));
+  }
+
+  function hydrateFromDOM() {
+    const seeds = document.querySelectorAll("[data-toast]");
+    seeds.forEach((node) => {
+      const message = node.getAttribute("data-toast-message");
+      const type = node.getAttribute("data-toast-type") || "info";
+      if (message) show(message, type);
+      node.remove();
+    });
+  }
+
+  window.Toast = { show, dismiss };
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", hydrateFromDOM);
+  } else {
+    hydrateFromDOM();
+  }
+})();

--- a/public/css/toast.css
+++ b/public/css/toast.css
@@ -1,0 +1,175 @@
+/**
+ * Non-blocking toast notifications.
+ * Replaces the page-pushing Bootstrap alerts in flash.ejs.
+ * Brand-aligned with the existing red/pink palette.
+ */
+
+.toast-stack {
+  position: fixed;
+  top: 5.75rem;
+  right: 1rem;
+  z-index: 1080;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  pointer-events: none;
+  max-width: min(360px, calc(100vw - 2rem));
+}
+
+.toast-item {
+  pointer-events: auto;
+  position: relative;
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  padding: 0.85rem 2.4rem 0.85rem 1rem;
+  background: #ffffff;
+  border-radius: 0.75rem;
+  box-shadow: 0 8px 28px rgba(34, 34, 34, 0.12),
+    0 2px 6px rgba(34, 34, 34, 0.06);
+  border: 1px solid rgba(34, 34, 34, 0.06);
+  border-left: 4px solid #fe424d;
+  font-family: "Plus Jakarta Sans", sans-serif;
+  font-size: 0.92rem;
+  font-weight: 500;
+  color: #222;
+  line-height: 1.35;
+  overflow: hidden;
+  transform: translateX(120%);
+  opacity: 0;
+  transition: transform 0.32s cubic-bezier(0.22, 1, 0.36, 1),
+    opacity 0.25s ease-out;
+}
+
+.toast-item.is-visible {
+  transform: translateX(0);
+  opacity: 1;
+}
+
+.toast-item.is-leaving {
+  transform: translateX(120%);
+  opacity: 0;
+}
+
+.toast-item--success {
+  border-left-color: #1f9d55;
+}
+
+.toast-item--error {
+  border-left-color: #fe424d;
+}
+
+.toast-item--info {
+  border-left-color: #e82d72;
+}
+
+.toast-item__icon {
+  flex-shrink: 0;
+  width: 1.4rem;
+  height: 1.4rem;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.85rem;
+  color: #ffffff;
+  margin-top: 0.05rem;
+}
+
+.toast-item--success .toast-item__icon {
+  background: #1f9d55;
+}
+
+.toast-item--error .toast-item__icon {
+  background: #fe424d;
+}
+
+.toast-item--info .toast-item__icon {
+  background: linear-gradient(to right, #e82d72 0%, #fe346a 48%, #ff375f 100%);
+}
+
+.toast-item__body {
+  flex: 1;
+  min-width: 0;
+  word-wrap: break-word;
+}
+
+.toast-item__close {
+  position: absolute;
+  top: 0.45rem;
+  right: 0.5rem;
+  background: transparent;
+  border: none;
+  width: 1.6rem;
+  height: 1.6rem;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: #888;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.toast-item__close:hover {
+  background: rgba(34, 34, 34, 0.06);
+  color: #222;
+}
+
+.toast-item__progress {
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  height: 3px;
+  width: 100%;
+  background: currentColor;
+  opacity: 0.18;
+  transform-origin: left center;
+  animation: toast-progress linear forwards;
+}
+
+.toast-item--success .toast-item__progress {
+  color: #1f9d55;
+}
+
+.toast-item--error .toast-item__progress {
+  color: #fe424d;
+}
+
+.toast-item--info .toast-item__progress {
+  color: #e82d72;
+}
+
+@keyframes toast-progress {
+  from {
+    transform: scaleX(1);
+  }
+  to {
+    transform: scaleX(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .toast-item {
+    transition: opacity 0.2s ease;
+    transform: none;
+  }
+  .toast-item.is-leaving {
+    transform: none;
+  }
+  .toast-item__progress {
+    animation: none;
+    display: none;
+  }
+}
+
+@media (max-width: 575px) {
+  .toast-stack {
+    top: auto;
+    bottom: 5rem;
+    right: 0.75rem;
+    left: 0.75rem;
+    max-width: none;
+  }
+}

--- a/views/includes/flash.ejs
+++ b/views/includes/flash.ejs
@@ -1,40 +1,16 @@
-<% if(successMsg && successMsg.length){ %>
-<div
-  class="alert alert-success mt-1 alert-dismissible fade show col-lg-6 col-12 offset-lg-3"
-  role="alert"
->
-  <%= successMsg %>
-  <button
-    type="button"
-    class="btn-close"
-    data-bs-dismiss="alert"
-    aria-label="Close"
-  ></button>
-</div>
-<% } %> <% if(errorMsg && errorMsg.length){ %>
-<div
-  class="alert alert-danger mt-1 alert-dismissible fade show col-lg-6 col-12 offset-lg-3"
-  role="alert"
->
-  <%= errorMsg %>
-  <button
-    type="button"
-    class="btn-close"
-    data-bs-dismiss="alert"
-    aria-label="Close"
-  ></button>
-</div>
-<% } %> <% if(updateMsg && updateMsg.length){ %>
-<div
-  class="alert alert-primary mt-1 alert-dismissible fade show col-lg-6 col-12 offset-lg-3"
-  role="alert"
->
-  <%= updateMsg %>
-  <button
-    type="button"
-    class="btn-close"
-    data-bs-dismiss="alert"
-    aria-label="Close"
-  ></button>
-</div>
+<%# Flash messages are seeded as data nodes and hydrated into toasts by toast.js %>
+<% if (successMsg && successMsg.length) { %>
+  <% successMsg.forEach(function (msg) { %>
+    <span data-toast data-toast-type="success" data-toast-message="<%= msg %>" hidden></span>
+  <% }) %>
+<% } %>
+<% if (errorMsg && errorMsg.length) { %>
+  <% errorMsg.forEach(function (msg) { %>
+    <span data-toast data-toast-type="error" data-toast-message="<%= msg %>" hidden></span>
+  <% }) %>
+<% } %>
+<% if (updateMsg && updateMsg.length) { %>
+  <% updateMsg.forEach(function (msg) { %>
+    <span data-toast data-toast-type="info" data-toast-message="<%= msg %>" hidden></span>
+  <% }) %>
 <% } %>

--- a/views/layouts/boilerplate.ejs
+++ b/views/layouts/boilerplate.ejs
@@ -35,6 +35,7 @@
     <script src="https://cdn.lordicon.com/lordicon.js"></script>
     <link rel="stylesheet" href="/css/style.css" />
     <link rel="stylesheet" href="/css/rating.css" />
+    <link rel="stylesheet" href="/css/toast.css" />
     <link
       href="https://api.mapbox.com/mapbox-gl-js/v3.3.0/mapbox-gl.css" rel="stylesheet"/>
     <script src="https://api.mapbox.com/mapbox-gl-js/v3.3.0/mapbox-gl.js"></script>
@@ -54,6 +55,7 @@
       crossorigin="anonymous"
     ></script>
 
+    <script src="/JS/toast.js"></script>
     <script src="/JS/script.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- Replaces the page-pushing Bootstrap alerts in \`flash.ejs\` with a non-blocking toast system pinned to the top-right (bottom on mobile).
- Brand-aligned: red/pink accents, Plus Jakarta Sans, rounded \`0.75rem\` corners — matches the existing card aesthetic.
- Progress bar countdown, pause-on-hover, click X or auto-dismiss after 4s. Stack supports multiple toasts.
- Theme is preserved: no existing CSS rules removed, only \`toast.css\` added.

## Files
- \`public/css/toast.css\` (new) — component styles, reduced-motion + responsive variants
- \`public/JS/toast.js\` (new) — \`window.Toast.show(message, type, duration)\` API + DOM hydration
- \`views/includes/flash.ejs\` — emits hidden \`data-toast\` seeds instead of alert markup
- \`views/layouts/boilerplate.ejs\` — wires \`toast.css\` and \`toast.js\`

## A11y
- \`role=\"alert\"\` + \`aria-live=\"assertive\"\` for errors; \`role=\"status\"\` + \`aria-live=\"polite\"\` for success/info
- Honors \`prefers-reduced-motion\`: drops slide animation, hides progress bar

## Test plan
- [ ] Trigger a flash success (e.g. login) and confirm a toast appears top-right and dismisses after 4s
- [ ] Trigger a flash error and confirm red toast with error styling
- [ ] Resize <575px and confirm toasts pin to bottom above the mobile footer
- [ ] Call \`Toast.show('Hi', 'info')\` from the console; confirm it stacks above any existing toast