### PR TITLE
UI: dark mode toggle (CSS variables, theme preserved)

### DIFF
--- a/public/JS/theme.js
+++ b/public/JS/theme.js
@@ -1,0 +1,64 @@
+(function () {
+  "use strict";
+
+  const STORAGE_KEY = "wl-theme";
+
+  function applyTheme(theme) {
+    document.documentElement.setAttribute("data-theme", theme);
+  }
+
+  function readStoredTheme() {
+    try {
+      return localStorage.getItem(STORAGE_KEY);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  function persistTheme(theme) {
+    try {
+      localStorage.setItem(STORAGE_KEY, theme);
+    } catch (_) {
+      /* swallow quota / private-mode errors */
+    }
+  }
+
+  function currentTheme() {
+    return document.documentElement.getAttribute("data-theme") === "dark"
+      ? "dark"
+      : "light";
+  }
+
+  function toggleTheme() {
+    const next = currentTheme() === "dark" ? "light" : "dark";
+    applyTheme(next);
+    persistTheme(next);
+    if (window.Toast) {
+      window.Toast.show(
+        next === "dark" ? "Dark mode on" : "Light mode on",
+        "info",
+        2000
+      );
+    }
+  }
+
+  function bindToggle() {
+    const btn = document.querySelector("[data-theme-toggle]");
+    if (!btn) return;
+    btn.addEventListener("click", toggleTheme);
+
+    if (window.matchMedia) {
+      const mq = window.matchMedia("(prefers-color-scheme: dark)");
+      mq.addEventListener?.("change", (e) => {
+        if (readStoredTheme()) return;
+        applyTheme(e.matches ? "dark" : "light");
+      });
+    }
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", bindToggle);
+  } else {
+    bindToggle();
+  }
+})();

--- a/public/css/theme.css
+++ b/public/css/theme.css
@@ -1,0 +1,209 @@
+/**
+ * Dark theme overrides.
+ * Activated by setting [data-theme="dark"] on <html>.
+ * Brand colors are preserved — only neutrals shift.
+ */
+
+:root {
+  --wl-bg: #ffffff;
+  --wl-surface: #ffffff;
+  --wl-surface-2: #f7f7f7;
+  --wl-text: #222222;
+  --wl-text-muted: #6b6b6b;
+  --wl-border: rgba(0, 0, 0, 0.08);
+  --wl-elevated-shadow: 0 8px 28px rgba(34, 34, 34, 0.12);
+  --wl-brand: #fe424d;
+}
+
+[data-theme="dark"] {
+  --wl-bg: #121214;
+  --wl-surface: #1c1c1e;
+  --wl-surface-2: #232326;
+  --wl-text: #ededed;
+  --wl-text-muted: #a8a8ad;
+  --wl-border: rgba(255, 255, 255, 0.08);
+  --wl-elevated-shadow: 0 10px 30px rgba(0, 0, 0, 0.6);
+  color-scheme: dark;
+}
+
+[data-theme="dark"] body {
+  background-color: var(--wl-bg);
+  color: var(--wl-text);
+}
+
+[data-theme="dark"] .navbar,
+[data-theme="dark"] #navbarNav {
+  background-color: var(--wl-surface) !important;
+  border-bottom-color: var(--wl-border) !important;
+}
+
+[data-theme="dark"] .nav-link {
+  color: var(--wl-text) !important;
+}
+
+[data-theme="dark"] #new-airbnb:hover,
+[data-theme="dark"] #explore:hover,
+[data-theme="dark"] #globe:hover {
+  background-color: rgba(255, 255, 255, 0.08);
+}
+
+[data-theme="dark"] .f-info {
+  background-color: var(--wl-surface-2);
+}
+
+[data-theme="dark"] .f-info-links a,
+[data-theme="dark"] .extra a,
+[data-theme="dark"] .extra a:hover {
+  color: var(--wl-text);
+}
+
+[data-theme="dark"] .footer {
+  background-color: var(--wl-surface);
+  border-top-color: var(--wl-border);
+}
+
+[data-theme="dark"] .footer a,
+[data-theme="dark"] #icon-footer,
+[data-theme="dark"] .icon-footer {
+  color: var(--wl-text-muted);
+}
+
+[data-theme="dark"] .listing-card,
+[data-theme="dark"] .card {
+  background-color: var(--wl-surface);
+  color: var(--wl-text);
+}
+
+[data-theme="dark"] .card-body p,
+[data-theme="dark"] .card-body .card-text {
+  color: var(--wl-text);
+}
+
+[data-theme="dark"] input[type="text"],
+[data-theme="dark"] input[type="password"],
+[data-theme="dark"] input[type="email"],
+[data-theme="dark"] input[type="number"],
+[data-theme="dark"] input[type="search"],
+[data-theme="dark"] textarea,
+[data-theme="dark"] select {
+  background-color: var(--wl-surface-2) !important;
+  color: var(--wl-text) !important;
+  border-color: rgba(255, 255, 255, 0.18) !important;
+}
+
+[data-theme="dark"] input::placeholder,
+[data-theme="dark"] textarea::placeholder {
+  color: var(--wl-text-muted);
+}
+
+[data-theme="dark"] input[type="text"]:focus,
+[data-theme="dark"] input[type="password"]:focus,
+[data-theme="dark"] input[type="email"]:focus,
+[data-theme="dark"] input[type="number"]:focus,
+[data-theme="dark"] textarea:focus {
+  border-color: var(--wl-brand) !important;
+}
+
+[data-theme="dark"] body::-webkit-scrollbar-track {
+  background: #2a2a2d;
+}
+
+[data-theme="dark"] body::-webkit-scrollbar-thumb {
+  background: #5a5a5e;
+}
+
+[data-theme="dark"] .toast-item {
+  background: var(--wl-surface);
+  color: var(--wl-text);
+  border-color: var(--wl-border);
+  box-shadow: var(--wl-elevated-shadow);
+}
+
+[data-theme="dark"] .toast-item__close {
+  color: var(--wl-text-muted);
+}
+
+[data-theme="dark"] .toast-item__close:hover {
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--wl-text);
+}
+
+[data-theme="dark"] .alert {
+  background-color: var(--wl-surface-2);
+  color: var(--wl-text);
+  border-color: var(--wl-border);
+}
+
+[data-theme="dark"] .modal-content,
+[data-theme="dark"] .dropdown-menu,
+[data-theme="dark"] .offcanvas {
+  background-color: var(--wl-surface);
+  color: var(--wl-text);
+  border-color: var(--wl-border);
+}
+
+[data-theme="dark"] .form-control,
+[data-theme="dark"] .form-select {
+  background-color: var(--wl-surface-2);
+  color: var(--wl-text);
+  border-color: rgba(255, 255, 255, 0.18);
+}
+
+[data-theme="dark"] hr {
+  border-color: var(--wl-border);
+}
+
+/**
+ * Theme toggle button — visible in both light and dark.
+ */
+
+.theme-toggle {
+  background: transparent;
+  border: 1px solid transparent;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  margin-right: 0.5rem;
+  color: #222;
+  font-size: 1rem;
+  transition: background-color 0.25s ease, color 0.25s ease,
+    transform 0.4s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.theme-toggle:hover {
+  background-color: rgba(207, 207, 207, 0.461);
+}
+
+.theme-toggle:focus-visible {
+  outline: 2px solid #fe424d;
+  outline-offset: 2px;
+}
+
+[data-theme="dark"] .theme-toggle {
+  color: #f3c969;
+}
+
+[data-theme="dark"] .theme-toggle:hover {
+  background-color: rgba(255, 255, 255, 0.08);
+}
+
+.theme-toggle__sun,
+.theme-toggle__moon {
+  transition: opacity 0.2s ease, transform 0.4s ease;
+}
+
+.theme-toggle__sun {
+  display: none;
+}
+
+[data-theme="dark"] .theme-toggle__sun {
+  display: inline-block;
+}
+
+[data-theme="dark"] .theme-toggle__moon {
+  display: none;
+}

--- a/views/includes/navbar.ejs
+++ b/views/includes/navbar.ejs
@@ -108,6 +108,16 @@ c201 -48 366 -92 368 -97 2 -5 -78 -50 -177 -99 -166 -82 -182 -89 -203 -76
         <a class="nav-link" href="/listings/new" id="new-airbnb"
           >Airbnb your home</a
         >
+        <button
+          type="button"
+          class="theme-toggle"
+          data-theme-toggle
+          aria-label="Toggle dark mode"
+          title="Toggle dark mode"
+        >
+          <i class="fa-solid fa-moon theme-toggle__moon" aria-hidden="true"></i>
+          <i class="fa-solid fa-sun theme-toggle__sun" aria-hidden="true"></i>
+        </button>
         <span class="material-symbols-outlined" id="globe">
           <lord-icon
             src="https://cdn.lordicon.com/pbbsmkso.json"

--- a/views/layouts/boilerplate.ejs
+++ b/views/layouts/boilerplate.ejs
@@ -4,6 +4,18 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>WanderLust</title>
+    <script>
+      (function () {
+        try {
+          var saved = localStorage.getItem("wl-theme");
+          var prefersDark =
+            window.matchMedia &&
+            window.matchMedia("(prefers-color-scheme: dark)").matches;
+          var theme = saved || (prefersDark ? "dark" : "light");
+          document.documentElement.setAttribute("data-theme", theme);
+        } catch (e) {}
+      })();
+    </script>
     <link rel="icon" href="Assets/travel-agency.png" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -35,6 +47,7 @@
     <script src="https://cdn.lordicon.com/lordicon.js"></script>
     <link rel="stylesheet" href="/css/style.css" />
     <link rel="stylesheet" href="/css/rating.css" />
+    <link rel="stylesheet" href="/css/theme.css" />
     <link
       href="https://api.mapbox.com/mapbox-gl-js/v3.3.0/mapbox-gl.css" rel="stylesheet"/>
     <script src="https://api.mapbox.com/mapbox-gl-js/v3.3.0/mapbox-gl.js"></script>
@@ -54,6 +67,7 @@
       crossorigin="anonymous"
     ></script>
 
+    <script src="/JS/theme.js"></script>
     <script src="/JS/script.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- Adds a dark mode toggle next to the globe icon. Sun/moon icon swap, persisted in \`localStorage\`, respects \`prefers-color-scheme\` on first visit.
- Light theme = the existing styles, **untouched**. Dark theme is layered on via \`[data-theme=\"dark\"]\` overrides in a new \`theme.css\`.
- Brand colors (\`#fe424d\`, gradient pinks) preserved in both modes — they're the part that makes the site feel like itself.
- FOUC-prevention inline script in \`<head>\` sets the theme attribute before CSS loads, so dark-mode users never flash white.

## Files
- \`public/css/theme.css\` (new) — dark overrides + toggle button styles
- \`public/JS/theme.js\` (new) — toggle logic, storage, OS-pref listener
- \`views/layouts/boilerplate.ejs\` — wires inline FOUC script, theme.css, theme.js
- \`views/includes/navbar.ejs\` — adds the toggle button

## A11y
- \`aria-label=\"Toggle dark mode\"\`, \`title\` tooltip, focus ring matches brand
- Toast confirmation on toggle (subtle, dismisses in 2s)

## Test plan
- [ ] Toggle dark/light: navbar, footer, cards, inputs all flip cleanly
- [ ] Refresh after toggling — choice persists
- [ ] Open in incognito with system set to dark — site loads dark with no flash
- [ ] Confirm brand red is still red on listing buttons in both modes