### PR TITLE
UI: image-load skeletons for listing cards (shimmer)

### DIFF
--- a/public/JS/skeleton.js
+++ b/public/JS/skeleton.js
@@ -1,0 +1,38 @@
+(function () {
+  "use strict";
+
+  function markLoaded(wrap) {
+    wrap.classList.remove("is-loading");
+    wrap.classList.add("is-loaded");
+  }
+
+  function attachToImage(wrap) {
+    const img = wrap.querySelector("img");
+    if (!img) return;
+    if (img.complete && img.naturalWidth > 0) {
+      markLoaded(wrap);
+      return;
+    }
+    img.addEventListener("load", () => markLoaded(wrap), { once: true });
+    img.addEventListener(
+      "error",
+      () => {
+        wrap.classList.remove("is-loading");
+        wrap.classList.add("is-error");
+      },
+      { once: true }
+    );
+  }
+
+  function init() {
+    document
+      .querySelectorAll(".card-image-wrap.is-loading")
+      .forEach(attachToImage);
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+})();

--- a/public/css/skeleton.css
+++ b/public/css/skeleton.css
@@ -1,0 +1,111 @@
+/**
+ * Image-load skeleton + page-load skeleton stack for the listings index.
+ * Matches existing card sizing (18.75rem image, 1rem rounded corners).
+ */
+
+@keyframes wl-shimmer {
+  0% {
+    background-position: -120% 0;
+  }
+  100% {
+    background-position: 120% 0;
+  }
+}
+
+.skeleton-base,
+.card-image-wrap.is-loading::before {
+  background: linear-gradient(
+    90deg,
+    #ececec 0%,
+    #f6f6f6 50%,
+    #ececec 100%
+  );
+  background-size: 240% 100%;
+  animation: wl-shimmer 1.4s ease-in-out infinite;
+}
+
+[data-theme="dark"] .skeleton-base,
+[data-theme="dark"] .card-image-wrap.is-loading::before {
+  background: linear-gradient(
+    90deg,
+    #1f1f22 0%,
+    #2a2a2d 50%,
+    #1f1f22 100%
+  );
+  background-size: 240% 100%;
+}
+
+.card-image-wrap {
+  position: relative;
+  width: 100%;
+  border-radius: 1rem;
+  overflow: hidden;
+}
+
+.card-image-wrap.is-loading::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: 1rem;
+  z-index: 1;
+}
+
+.card-image-wrap > img {
+  display: block;
+  width: 100%;
+  height: 18.75rem;
+  object-fit: cover;
+  border-radius: 1rem;
+  opacity: 0;
+  transition: opacity 0.35s ease-in-out;
+  position: relative;
+  z-index: 2;
+}
+
+.card-image-wrap.is-loaded > img {
+  opacity: 1;
+}
+
+/**
+ * Pre-paint skeleton stack — used for cards that haven't rendered yet
+ * (e.g. when AJAX-fetched in later iterations of the search feature).
+ */
+.skeleton-card {
+  display: block;
+  padding: 0.5rem;
+}
+
+.skeleton-card__image {
+  width: 100%;
+  height: 18.75rem;
+  border-radius: 1rem;
+  margin-bottom: 0.85rem;
+}
+
+.skeleton-card__title {
+  height: 1rem;
+  width: 70%;
+  border-radius: 0.35rem;
+  margin-bottom: 0.55rem;
+}
+
+.skeleton-card__price {
+  height: 0.85rem;
+  width: 45%;
+  border-radius: 0.35rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .skeleton-base,
+  .card-image-wrap.is-loading::before {
+    animation: none;
+    background: #ececec;
+  }
+  [data-theme="dark"] .skeleton-base,
+  [data-theme="dark"] .card-image-wrap.is-loading::before {
+    background: #232326;
+  }
+  .card-image-wrap > img {
+    transition: none;
+  }
+}

--- a/views/listings/index.ejs
+++ b/views/listings/index.ejs
@@ -1,6 +1,7 @@
 <% layout("layouts/boilerplate") -%>
 
 <link rel="stylesheet" href="/css/index.css" />
+<link rel="stylesheet" href="/css/skeleton.css" />
 
 <br />
 <div class="tax-toggle toggler">
@@ -82,13 +83,14 @@ include("../includes/filters.ejs") %>
       <div class="favorite-tag">Guest favourite</div>
       <% } %>
 
-      <img
-        src="<%=listing.image.url%>"
-        class="card-img-top"
-        alt="Listing Image"
-        style="height: 18.75rem"
-        loading="lazy"
-      />
+      <div class="card-image-wrap is-loading">
+        <img
+          src="<%=listing.image.url%>"
+          class="card-img-top"
+          alt="Listing Image"
+          loading="lazy"
+        />
+      </div>
 
       <form action="/wishlists/add" method="POST">
         <% if(currUser){ %>
@@ -146,5 +148,6 @@ include("../includes/filters.ejs") %>
   <% } %>
 </div>
 
+<script src="/JS/skeleton.js"></script>
 <script src="/JS/index.js"></script>
 <script src="/JS/currency.js"></script>


### PR DESCRIPTION
## Summary
- Wraps each card image in \`.card-image-wrap.is-loading\`; a shimmering pseudo-element fills the slot until the image's \`load\` event fires.
- Smooth opacity fade-in on load, instant if the image was already cached.
- Light + dark shimmer palettes; static fallback for \`prefers-reduced-motion\`.
- Sized to match the existing 18.75rem card image height — no layout shift, no theme drift.

## Files
- \`public/css/skeleton.css\` (new)
- \`public/JS/skeleton.js\` (new)
- \`views/listings/index.ejs\` — wraps img, links new CSS/JS

## Test plan
- [ ] Hard reload the listings index on slow 3G — every card shows a shimmer until its image lands
- [ ] Reload on Fast 3G — cached images skip the shimmer and appear instantly
- [ ] Toggle dark mode — shimmer uses dark palette
- [ ] Toggle macOS \"Reduce motion\" — shimmer becomes a static placeholder