### PR TITLE
UI: sticky compact header on scroll

### DIFF
--- a/public/JS/header-scroll.js
+++ b/public/JS/header-scroll.js
@@ -1,0 +1,22 @@
+(function () {
+  "use strict";
+
+  const THRESHOLD = 80;
+  let ticking = false;
+
+  function update() {
+    const scrolled = window.scrollY > THRESHOLD;
+    document.body.dataset.navScrolled = scrolled ? "true" : "false";
+    ticking = false;
+  }
+
+  function onScroll() {
+    if (!ticking) {
+      window.requestAnimationFrame(update);
+      ticking = true;
+    }
+  }
+
+  window.addEventListener("scroll", onScroll, { passive: true });
+  update();
+})();

--- a/public/css/header-scroll.css
+++ b/public/css/header-scroll.css
@@ -1,0 +1,51 @@
+/**
+ * Sticky compact header — when the page is scrolled past 80px, the navbar
+ * shrinks (less padding, smaller logo) and gains a subtle elevation shadow.
+ * Toggling is done by header-scroll.js setting body[data-nav-scrolled].
+ */
+
+.navbar#nav {
+  transition: height 0.28s cubic-bezier(0.22, 1, 0.36, 1),
+    padding 0.28s cubic-bezier(0.22, 1, 0.36, 1),
+    box-shadow 0.28s ease, background-color 0.28s ease;
+  will-change: height, padding;
+}
+
+body[data-nav-scrolled="true"] .navbar#nav {
+  height: 3.75rem !important;
+  padding-inline: 1rem !important;
+  box-shadow: 0 4px 18px rgba(0, 0, 0, 0.07);
+  backdrop-filter: saturate(180%) blur(8px);
+  background-color: rgba(255, 255, 255, 0.92);
+}
+
+[data-theme="dark"] body[data-nav-scrolled="true"] .navbar#nav,
+body[data-nav-scrolled="true"][data-theme="dark"] .navbar#nav {
+  background-color: rgba(28, 28, 30, 0.92);
+  box-shadow: 0 4px 18px rgba(0, 0, 0, 0.45);
+}
+
+body[data-nav-scrolled="true"] .svg-icon#logo {
+  width: 2.5rem !important;
+  height: 2.5rem !important;
+  transition: width 0.28s ease, height 0.28s ease;
+}
+
+body[data-nav-scrolled="true"] #explore,
+body[data-nav-scrolled="true"] #new-airbnb {
+  font-size: 0.85rem;
+}
+
+body[data-nav-scrolled="true"] .searchBox {
+  transform: scale(0.92);
+  transform-origin: right center;
+  transition: transform 0.28s ease;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .navbar#nav,
+  body[data-nav-scrolled="true"] .svg-icon#logo,
+  body[data-nav-scrolled="true"] .searchBox {
+    transition: none;
+  }
+}

--- a/views/layouts/boilerplate.ejs
+++ b/views/layouts/boilerplate.ejs
@@ -35,6 +35,7 @@
     <script src="https://cdn.lordicon.com/lordicon.js"></script>
     <link rel="stylesheet" href="/css/style.css" />
     <link rel="stylesheet" href="/css/rating.css" />
+    <link rel="stylesheet" href="/css/header-scroll.css" />
     <link
       href="https://api.mapbox.com/mapbox-gl-js/v3.3.0/mapbox-gl.css" rel="stylesheet"/>
     <script src="https://api.mapbox.com/mapbox-gl-js/v3.3.0/mapbox-gl.js"></script>
@@ -54,6 +55,7 @@
       crossorigin="anonymous"
     ></script>
 
+    <script src="/JS/header-scroll.js"></script>
     <script src="/JS/script.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- Adds a scroll-condensed mode to the navbar: at \`scrollY > 80\`, the bar shrinks, gains a soft elevation shadow, and applies a translucent backdrop-blur — the Airbnb pattern.
- Logo and search box scale down so the bar stays balanced. Existing \`sticky-top\` behavior is unchanged.
- rAF-throttled scroll listener with \`{ passive: true }\` for smooth FPS.
- Honors reduced motion and dark mode.

## Files
- \`public/css/header-scroll.css\` (new)
- \`public/JS/header-scroll.js\` (new)
- \`views/layouts/boilerplate.ejs\` — wires CSS + JS

## Test plan
- [ ] Scroll down on listings index; navbar shrinks smoothly past 80px
- [ ] Scroll back up; navbar restores to full size
- [ ] Switch to dark mode and confirm the condensed bar uses the dark translucent backdrop
- [ ] Toggle macOS reduce motion; transitions are skipped