### PR TITLE
UI: image carousel on listing cards

### DIFF
--- a/models/listing.js
+++ b/models/listing.js
@@ -20,6 +20,12 @@ const listingSchema = Schema({
     url: String,
     filename: String,
   },
+  gallery: [
+    {
+      url: String,
+      filename: String,
+    },
+  ],
   price: {
     type: Number,
     min: 0,

--- a/public/JS/card-carousel.js
+++ b/public/JS/card-carousel.js
@@ -1,0 +1,72 @@
+(function () {
+  "use strict";
+
+  function initCarousel(root) {
+    const track = root.querySelector(".card-carousel__track");
+    const slides = Array.from(root.querySelectorAll(".card-carousel__slide"));
+    if (!track || slides.length <= 1) {
+      root.classList.add("card-carousel--single");
+      return;
+    }
+
+    let index = 0;
+    const dots = Array.from(root.querySelectorAll(".card-carousel__dot"));
+    const prevBtn = root.querySelector(".card-carousel__btn--prev");
+    const nextBtn = root.querySelector(".card-carousel__btn--next");
+
+    function go(target) {
+      index = (target + slides.length) % slides.length;
+      track.style.transform = `translateX(-${index * 100}%)`;
+      dots.forEach((d, i) => d.classList.toggle("is-active", i === index));
+    }
+
+    prevBtn?.addEventListener("click", (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      go(index - 1);
+    });
+
+    nextBtn?.addEventListener("click", (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      go(index + 1);
+    });
+
+    dots.forEach((dot, i) => {
+      dot.addEventListener("click", (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        go(i);
+      });
+    });
+
+    let touchStartX = null;
+    track.addEventListener(
+      "touchstart",
+      (e) => {
+        touchStartX = e.touches[0].clientX;
+      },
+      { passive: true }
+    );
+    track.addEventListener(
+      "touchend",
+      (e) => {
+        if (touchStartX == null) return;
+        const dx = e.changedTouches[0].clientX - touchStartX;
+        if (Math.abs(dx) > 40) go(index + (dx < 0 ? 1 : -1));
+        touchStartX = null;
+      },
+      { passive: true }
+    );
+  }
+
+  function init() {
+    document.querySelectorAll(".card-carousel").forEach(initCarousel);
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+})();

--- a/public/css/card-carousel.css
+++ b/public/css/card-carousel.css
@@ -1,0 +1,122 @@
+/**
+ * Listing-card image carousel.
+ * Pure CSS chrome + tiny JS. Hidden when only one slide exists.
+ */
+
+.card-carousel {
+  position: relative;
+  width: 100%;
+  border-radius: 1rem;
+  overflow: hidden;
+  background: #f3f3f3;
+}
+
+[data-theme="dark"] .card-carousel {
+  background: #232326;
+}
+
+.card-carousel__track {
+  display: flex;
+  width: 100%;
+  height: 18.75rem;
+  transform: translateX(0);
+  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1);
+  will-change: transform;
+}
+
+.card-carousel__slide {
+  flex: 0 0 100%;
+  height: 100%;
+}
+
+.card-carousel__slide img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+  border-radius: 0;
+}
+
+.card-carousel__btn {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 2rem;
+  height: 2rem;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.92);
+  color: #222;
+  border: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  font-size: 0.85rem;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.18);
+  opacity: 0;
+  transition: opacity 0.2s ease, transform 0.2s ease, background-color 0.2s ease;
+  z-index: 3;
+}
+
+.card-carousel__btn:hover {
+  background: #ffffff;
+  transform: translateY(-50%) scale(1.06);
+}
+
+.card-carousel__btn--prev {
+  left: 0.6rem;
+}
+
+.card-carousel__btn--next {
+  right: 0.6rem;
+}
+
+.card-carousel:hover .card-carousel__btn,
+.card-carousel:focus-within .card-carousel__btn {
+  opacity: 1;
+}
+
+.card-carousel__btn[disabled] {
+  opacity: 0 !important;
+  pointer-events: none;
+}
+
+.card-carousel__dots {
+  position: absolute;
+  bottom: 0.65rem;
+  left: 50%;
+  transform: translateX(-50%);
+  display: inline-flex;
+  gap: 0.32rem;
+  padding: 0.3rem 0.55rem;
+  border-radius: 1rem;
+  background: rgba(0, 0, 0, 0.18);
+  z-index: 3;
+}
+
+.card-carousel__dot {
+  width: 0.4rem;
+  height: 0.4rem;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.65);
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  transition: background-color 0.2s ease, transform 0.2s ease;
+}
+
+.card-carousel__dot.is-active {
+  background: #ffffff;
+  transform: scale(1.25);
+}
+
+.card-carousel--single .card-carousel__btn,
+.card-carousel--single .card-carousel__dots {
+  display: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .card-carousel__track {
+    transition: none;
+  }
+}

--- a/views/listings/index.ejs
+++ b/views/listings/index.ejs
@@ -1,6 +1,7 @@
 <% layout("layouts/boilerplate") -%>
 
 <link rel="stylesheet" href="/css/index.css" />
+<link rel="stylesheet" href="/css/card-carousel.css" />
 
 <br />
 <div class="tax-toggle toggler">
@@ -82,13 +83,35 @@ include("../includes/filters.ejs") %>
       <div class="favorite-tag">Guest favourite</div>
       <% } %>
 
-      <img
-        src="<%=listing.image.url%>"
-        class="card-img-top"
-        alt="Listing Image"
-        style="height: 18.75rem"
-        loading="lazy"
-      />
+      <%
+        const slides = [listing.image].concat(listing.gallery || []).filter(s => s && s.url);
+      %>
+      <div class="card-carousel <%= slides.length <= 1 ? 'card-carousel--single' : '' %>">
+        <div class="card-carousel__track">
+          <% slides.forEach(function (slide, i) { %>
+            <div class="card-carousel__slide">
+              <img
+                src="<%= slide.url %>"
+                alt="Listing image <%= i + 1 %>"
+                loading="<%= i === 0 ? 'eager' : 'lazy' %>"
+              />
+            </div>
+          <% }) %>
+        </div>
+        <% if (slides.length > 1) { %>
+          <button type="button" class="card-carousel__btn card-carousel__btn--prev" aria-label="Previous photo">
+            <i class="fa-solid fa-chevron-left" aria-hidden="true"></i>
+          </button>
+          <button type="button" class="card-carousel__btn card-carousel__btn--next" aria-label="Next photo">
+            <i class="fa-solid fa-chevron-right" aria-hidden="true"></i>
+          </button>
+          <div class="card-carousel__dots" aria-hidden="true">
+            <% slides.forEach(function (_, i) { %>
+              <button type="button" class="card-carousel__dot <%= i === 0 ? 'is-active' : '' %>" tabindex="-1"></button>
+            <% }) %>
+          </div>
+        <% } %>
+      </div>
 
       <form action="/wishlists/add" method="POST">
         <% if(currUser){ %>
@@ -146,5 +169,6 @@ include("../includes/filters.ejs") %>
   <% } %>
 </div>
 
+<script src="/JS/card-carousel.js"></script>
 <script src="/JS/index.js"></script>
 <script src="/JS/currency.js"></script>


### PR DESCRIPTION
## Summary
- Adds an optional \`listing.gallery\` array to the schema. The card now renders \`image\` + gallery as a swipeable carousel.
- Single-image listings get the same look as before — carousel chrome auto-hides when there's only one slide.
- Hover-revealed prev/next buttons (Airbnb pattern), clickable dots, touch-swipe, keyboard-friendly.
- Buttons \`stopPropagation\` so paging through photos doesn't accidentally navigate to the listing.

## Files
- \`models/listing.js\` — adds \`gallery: [{ url, filename }]\`
- \`public/css/card-carousel.css\` (new)
- \`public/JS/card-carousel.js\` (new)
- \`views/listings/index.ejs\` — replaces single \`<img>\` with carousel block

## Notes
- This PR adds the rendering path. A follow-up PR can add the multi-file upload to \`new\`/\`edit\` listing forms (multer already supports it).

## Test plan
- [ ] Confirm existing single-image listings render identically (no arrows / dots visible)
- [ ] Manually update a listing in Mongo to add 2 gallery images; reload index — arrows + dots appear, swipe works on touch
- [ ] Click prev/next; URL doesn't change (stopPropagation guard works)
- [ ] Dark mode shows the carousel background tile