### PR TITLE
UI: list + map split view on filter results

### DIFF
--- a/public/JS/filter-split.js
+++ b/public/JS/filter-split.js
@@ -1,0 +1,117 @@
+(function () {
+  "use strict";
+
+  function init() {
+    const toggleBtn = document.querySelector("[data-split-view-toggle]");
+    const splitRoot = document.querySelector(".filter-split");
+    if (!toggleBtn || !splitRoot) return;
+
+    const dataNode = document.getElementById("filter-split-data");
+    if (!dataNode) return;
+    let payload;
+    try {
+      payload = JSON.parse(dataNode.textContent || "{}");
+    } catch (_) {
+      return;
+    }
+
+    const listings = (payload.listings || []).filter(
+      (l) => l && l.coordinates && l.coordinates.length === 2
+    );
+    const mapToken = payload.mapToken;
+    if (!mapToken || listings.length === 0) {
+      toggleBtn.disabled = true;
+      toggleBtn.title = "Map view unavailable";
+      return;
+    }
+
+    let map;
+    let markers = new Map();
+    let initialized = false;
+    let activeListingId = null;
+
+    function buildMap() {
+      if (initialized) return;
+      initialized = true;
+      mapboxgl.accessToken = mapToken;
+      const center = listings[0].coordinates;
+      map = new mapboxgl.Map({
+        container: splitRoot.querySelector(".filter-split__map"),
+        style: "mapbox://styles/mapbox/streets-v12",
+        center,
+        zoom: 4,
+      });
+
+      const bounds = new mapboxgl.LngLatBounds();
+
+      listings.forEach((listing) => {
+        const el = document.createElement("button");
+        el.type = "button";
+        el.className = "wl-price-marker";
+        el.textContent = "₹" + Number(listing.price || 0).toLocaleString("en-IN");
+        el.setAttribute("aria-label", listing.title || "Listing");
+
+        const marker = new mapboxgl.Marker({ element: el })
+          .setLngLat(listing.coordinates)
+          .addTo(map);
+        markers.set(listing.id, { marker, el });
+        bounds.extend(listing.coordinates);
+
+        el.addEventListener("mouseenter", () => highlight(listing.id, true));
+        el.addEventListener("mouseleave", () => highlight(listing.id, false));
+        el.addEventListener("click", () => selectListing(listing.id));
+      });
+
+      if (listings.length > 1) {
+        map.fitBounds(bounds, { padding: 60, duration: 600, maxZoom: 12 });
+      }
+    }
+
+    function highlight(id, isHover) {
+      const card = splitRoot.querySelector(
+        `[data-listing-id="${id}"]`
+      );
+      const entry = markers.get(id);
+      if (card) card.classList.toggle("is-active-marker", isHover);
+      if (entry) entry.el.classList.toggle("is-hovered", isHover);
+    }
+
+    function selectListing(id) {
+      if (activeListingId && markers.get(activeListingId)) {
+        markers.get(activeListingId).el.classList.remove("is-selected");
+      }
+      activeListingId = id;
+      const entry = markers.get(id);
+      if (entry) entry.el.classList.add("is-selected");
+      const card = splitRoot.querySelector(`[data-listing-id="${id}"]`);
+      if (card) card.scrollIntoView({ behavior: "smooth", block: "center" });
+    }
+
+    splitRoot.querySelectorAll("[data-listing-id]").forEach((card) => {
+      const id = card.getAttribute("data-listing-id");
+      card.addEventListener("mouseenter", () => highlight(id, true));
+      card.addEventListener("mouseleave", () => highlight(id, false));
+    });
+
+    function setView(on) {
+      document.body.dataset.splitView = on ? "on" : "off";
+      toggleBtn.classList.toggle("is-active", on);
+      toggleBtn.setAttribute("aria-pressed", String(on));
+      if (on) {
+        buildMap();
+        setTimeout(() => map && map.resize(), 60);
+      }
+    }
+
+    toggleBtn.addEventListener("click", () => {
+      const on = document.body.dataset.splitView !== "on";
+      setView(on);
+    });
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+})();

--- a/public/css/filter-split.css
+++ b/public/css/filter-split.css
@@ -1,0 +1,147 @@
+/**
+ * Filter results split-view: scrollable card list on the left,
+ * sticky Mapbox map with price pins on the right.
+ * Toggleable; default keeps the existing grid view.
+ */
+
+.split-view-toolbar {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0.75rem 1rem 0.5rem;
+}
+
+.split-view-toolbar__toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.45rem 0.95rem;
+  border-radius: 1.4rem;
+  border: 1.5px solid rgba(0, 0, 0, 0.12);
+  background: #ffffff;
+  color: #222;
+  font-family: "Plus Jakarta Sans", sans-serif;
+  font-weight: 600;
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: background-color 0.2s ease, border-color 0.2s ease,
+    color 0.2s ease;
+}
+
+.split-view-toolbar__toggle:hover {
+  background: #f7f7f7;
+  border-color: rgba(0, 0, 0, 0.25);
+}
+
+.split-view-toolbar__toggle.is-active {
+  background: #222;
+  color: #ffffff;
+  border-color: #222;
+}
+
+[data-theme="dark"] .split-view-toolbar__toggle {
+  background: #1c1c1e;
+  color: #ededed;
+  border-color: rgba(255, 255, 255, 0.18);
+}
+
+[data-theme="dark"] .split-view-toolbar__toggle.is-active {
+  background: #fe424d;
+  color: #fff;
+  border-color: #fe424d;
+}
+
+.filter-split {
+  display: none;
+}
+
+body[data-split-view="on"] .filter-grid {
+  display: none;
+}
+
+body[data-split-view="on"] .filter-split {
+  display: grid;
+  grid-template-columns: minmax(0, 1.2fr) minmax(0, 1fr);
+  gap: 1rem;
+  height: calc(100vh - 6.5rem);
+  margin: 0 1rem 2rem;
+}
+
+.filter-split__list {
+  overflow-y: auto;
+  padding-right: 0.4rem;
+  scrollbar-gutter: stable;
+}
+
+.filter-split__map-wrap {
+  position: sticky;
+  top: 5.75rem;
+  height: 100%;
+  border-radius: 1rem;
+  overflow: hidden;
+  box-shadow: 0 6px 24px rgba(0, 0, 0, 0.08);
+}
+
+.filter-split__map {
+  width: 100%;
+  height: 100%;
+}
+
+.filter-split .listing-card {
+  margin-bottom: 1.5rem !important;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.25s ease;
+}
+
+.filter-split .listing-card.is-active-marker {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.12);
+}
+
+/* Price marker pin */
+.wl-price-marker {
+  background: #ffffff;
+  color: #222;
+  font-family: "Plus Jakarta Sans", sans-serif;
+  font-weight: 700;
+  font-size: 0.78rem;
+  padding: 0.32rem 0.65rem;
+  border-radius: 1.2rem;
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.18);
+  cursor: pointer;
+  transition: transform 0.2s ease, background-color 0.2s ease,
+    color 0.2s ease, box-shadow 0.2s ease;
+  white-space: nowrap;
+}
+
+.wl-price-marker:hover,
+.wl-price-marker.is-hovered,
+.wl-price-marker.is-selected {
+  background: #222;
+  color: #ffffff;
+  transform: scale(1.08);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.28);
+}
+
+.wl-price-marker.is-selected {
+  background: #fe424d;
+}
+
+[data-theme="dark"] .wl-price-marker {
+  background: #1c1c1e;
+  color: #ededed;
+  border-color: rgba(255, 255, 255, 0.12);
+}
+
+@media (max-width: 991px) {
+  body[data-split-view="on"] .filter-split {
+    grid-template-columns: minmax(0, 1fr);
+    height: auto;
+  }
+  body[data-split-view="on"] .filter-split__map-wrap {
+    position: static;
+    height: 22rem;
+  }
+}

--- a/views/listings/filter.ejs
+++ b/views/listings/filter.ejs
@@ -1,6 +1,7 @@
 <% layout("layouts/boilerplate") -%>
 
 <link rel="stylesheet" href="/css/index.css" />
+<link rel="stylesheet" href="/css/filter-split.css" />
 
 <style>
   .container {
@@ -57,13 +58,43 @@
     </div>
   </div>
 
-  <div class="row row-cols-xl-4 row-cols-lg-3 row-cols-md-2 row-cols-sm-1 mb-4">
-    <% for(let listing of listings){ %>
-    <!-- changed 'listings' to 'listing' -->
+  <div class="split-view-toolbar">
+    <button
+      type="button"
+      class="split-view-toolbar__toggle"
+      data-split-view-toggle
+      aria-pressed="false"
+    >
+      <i class="fa-solid fa-map-location-dot" aria-hidden="true"></i>
+      <span>Show map</span>
+    </button>
+  </div>
+
+  <%
+    const mappableListings = (listings || []).filter(function (l) {
+      return l && l.geometry && Array.isArray(l.geometry.coordinates) && l.geometry.coordinates.length === 2;
+    });
+    const splitPayload = {
+      mapToken: process.env.MAP_TOKEN || "",
+      listings: mappableListings.map(function (l) {
+        return {
+          id: String(l._id),
+          title: l.title,
+          price: l.price,
+          coordinates: l.geometry.coordinates,
+        };
+      })
+    };
+  %>
+  <script id="filter-split-data" type="application/json"><%- JSON.stringify(splitPayload) %></script>
+
+  <%
+    function renderCard(listing, extraClass) {
+      extraClass = extraClass || "";
+  %>
     <a href="/listings/<%=listing._id%>" id="listing-link">
-      <!-- changed 'listings' to 'listing' -->
       <div
-        class="card listing-card mt-3"
+        class="card listing-card mt-3 <%= extraClass %>"
         data-title="<%=listing.title.toLowerCase()%>"
         data-listing-id="<%=listing._id%>"
         data-bedrooms="<%= listing.bedrooms %>"
@@ -71,7 +102,6 @@
         data-accessibility="<%= listing.locked %>"
         data-type="<%= listing.typeOfPlace %>"
       >
-        <!-- Removed form tags as they are not necessary here -->
         <img
           src="<%=listing.image.url%>"
           class="card-img-top"
@@ -92,10 +122,8 @@
               <% if (currUser &&
               currUser.favoriteListings.includes(listing._id)) { %>
               <i class="fa-solid fa-heart" style="color: #ff385c"></i>
-              <!-- Filled heart -->
               <% } else { %>
               <i class="fa-solid fa-heart" style="color: rgb(64, 64, 64)"></i>
-              <!-- Empty heart -->
               <% } %>
             </p>
           </button>
@@ -125,9 +153,22 @@
         </div>
       </div>
     </a>
-    <% } %>
+  <% } %>
+
+  <div class="filter-grid row row-cols-xl-4 row-cols-lg-3 row-cols-md-2 row-cols-sm-1 mb-4">
+    <% for (let listing of listings) { renderCard(listing); } %>
+  </div>
+
+  <div class="filter-split" aria-hidden="true">
+    <div class="filter-split__list row row-cols-xl-2 row-cols-lg-1 row-cols-md-1 row-cols-sm-1">
+      <% for (let listing of listings) { renderCard(listing, "filter-split__card"); } %>
+    </div>
+    <div class="filter-split__map-wrap">
+      <div class="filter-split__map" aria-label="Listings map"></div>
+    </div>
   </div>
 </body>
 
 <script src="/JS/index.js"></script>
 <script src="/JS/currency.js"></script>
+<script src="/JS/filter-split.js"></script>


### PR DESCRIPTION
## Summary
- Adds a 'Show map' toggle on category filter pages. When on, the grid flips to a 60/40 layout: scrollable cards on the left, sticky Mapbox map on the right with custom price-pill markers.
- Hover a card → marker highlights. Hover a marker → card scrolls into view and elevates. Click a marker → card scrolls into focus and the marker turns brand red.
- Map is built lazily on first toggle (no perf cost when off). Bounds auto-fit the listings collection.
- Responsive: under 992px the layout collapses to a single column with the map below the list.

## Files
- \`public/css/filter-split.css\` (new)
- \`public/JS/filter-split.js\` (new)
- \`views/listings/filter.ejs\` — adds toolbar, dual-render grid + split, JSON data island

## Notes
- Requires \`MAP_TOKEN\` env var (already used by the show page).
- Listings without geometry coordinates are skipped from the map but still appear in the list.

## Test plan
- [ ] Open any category page, click 'Show map' — list compresses, map appears with price pins
- [ ] Hover a card and confirm the matching pin highlights
- [ ] Hover a pin and confirm the card elevates
- [ ] Click a pin and confirm the card scrolls into view and the pin turns red
- [ ] Resize <992px — map drops below list, still functional