### PR TITLE
UI: inline form validation (live, on blur + submit)

### DIFF
--- a/public/JS/form-validate.js
+++ b/public/JS/form-validate.js
@@ -1,0 +1,121 @@
+(function () {
+  "use strict";
+
+  const RULES = {
+    required: (v) => (v.trim().length > 0 ? null : "This field is required."),
+    email: (v) =>
+      /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(v.trim())
+        ? null
+        : "Enter a valid email address.",
+    minLength: (v, n) =>
+      v.trim().length >= n ? null : `Must be at least ${n} characters.`,
+    maxLength: (v, n) =>
+      v.trim().length <= n ? null : `Must be at most ${n} characters.`,
+    minNumber: (v, n) =>
+      Number(v) >= n ? null : `Must be greater than or equal to ${n}.`,
+    pattern: (v, regex) =>
+      new RegExp(regex).test(v) ? null : "Doesn't match the expected format.",
+  };
+
+  function validateInput(input) {
+    const value = input.value || "";
+    const rules = parseRules(input);
+
+    for (const [name, arg] of rules) {
+      const fn = RULES[name];
+      if (!fn) continue;
+      const message = fn(value, arg);
+      if (message) {
+        return input.dataset.validateMessage || message;
+      }
+    }
+    return null;
+  }
+
+  function parseRules(input) {
+    const rules = [];
+    if (input.required) rules.push(["required", null]);
+    if (input.type === "email" && input.value) rules.push(["email", null]);
+    if (input.minLength > 0) rules.push(["minLength", input.minLength]);
+    if (input.maxLength > 0 && input.maxLength < 524288)
+      rules.push(["maxLength", input.maxLength]);
+    if (input.type === "number" && input.min !== "")
+      rules.push(["minNumber", Number(input.min)]);
+    if (input.pattern) rules.push(["pattern", input.pattern]);
+    return rules;
+  }
+
+  function ensureFieldShell(input) {
+    let shell = input.closest(".wl-field");
+    if (shell) return shell;
+    const parent = input.parentElement;
+    if (!parent) return null;
+    parent.classList.add("wl-field");
+    shell = parent;
+    if (!shell.querySelector(".wl-field__error")) {
+      const err = document.createElement("p");
+      err.className = "wl-field__error";
+      err.setAttribute("aria-live", "polite");
+      shell.appendChild(err);
+    }
+    return shell;
+  }
+
+  function applyState(input, message) {
+    const shell = ensureFieldShell(input);
+    if (!shell) return;
+    const errEl = shell.querySelector(".wl-field__error");
+    shell.classList.toggle("is-invalid", Boolean(message));
+    shell.classList.toggle("is-valid", !message && (input.value || "").length > 0);
+    if (errEl) errEl.textContent = message || "";
+  }
+
+  function bindForm(form) {
+    const inputs = Array.from(
+      form.querySelectorAll("input, textarea, select")
+    ).filter((el) => el.type !== "hidden" && el.type !== "submit" && el.type !== "button");
+
+    inputs.forEach((input) => {
+      ensureFieldShell(input);
+      input.addEventListener("blur", () => {
+        input.closest(".wl-field")?.classList.add("is-touched");
+        applyState(input, validateInput(input));
+      });
+      input.addEventListener("input", () => {
+        const shell = input.closest(".wl-field");
+        if (shell?.classList.contains("is-touched")) {
+          applyState(input, validateInput(input));
+        }
+      });
+    });
+
+    form.addEventListener("submit", (e) => {
+      let firstInvalid = null;
+      inputs.forEach((input) => {
+        const shell = input.closest(".wl-field");
+        if (shell) shell.classList.add("is-touched");
+        const msg = validateInput(input);
+        applyState(input, msg);
+        if (msg && !firstInvalid) firstInvalid = input;
+      });
+      if (firstInvalid) {
+        e.preventDefault();
+        firstInvalid.focus({ preventScroll: false });
+        if (window.Toast)
+          window.Toast.show("Please fix the highlighted fields", "error", 3000);
+      }
+    });
+  }
+
+  function init() {
+    document
+      .querySelectorAll("form[data-validate-form]")
+      .forEach(bindForm);
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+})();

--- a/public/css/form-validate.css
+++ b/public/css/form-validate.css
@@ -1,0 +1,47 @@
+/**
+ * Inline form validation feedback.
+ * Lights up only after a field has been blurred or the form has been submitted.
+ */
+
+.wl-field {
+  position: relative;
+}
+
+.wl-field__error {
+  display: none;
+  margin-top: 0.4rem;
+  font-size: 0.82rem;
+  font-weight: 500;
+  color: #d12c3a;
+  font-family: "Plus Jakarta Sans", sans-serif;
+  line-height: 1.3;
+}
+
+.wl-field.is-touched.is-invalid .wl-field__error {
+  display: block;
+}
+
+.wl-field.is-touched.is-invalid > input,
+.wl-field.is-touched.is-invalid > textarea,
+.wl-field.is-touched.is-invalid > select,
+.wl-field.is-touched.is-invalid .form-control {
+  border-color: #d12c3a !important;
+  box-shadow: 0 0 0 3px rgba(209, 44, 58, 0.12);
+}
+
+.wl-field.is-touched.is-valid > input,
+.wl-field.is-touched.is-valid > textarea,
+.wl-field.is-touched.is-valid > select,
+.wl-field.is-touched.is-valid .form-control {
+  border-color: #1f9d55 !important;
+}
+
+[data-theme="dark"] .wl-field__error {
+  color: #ff7a85;
+}
+
+[data-theme="dark"] .wl-field.is-touched.is-invalid > input,
+[data-theme="dark"] .wl-field.is-touched.is-invalid .form-control {
+  border-color: #ff7a85 !important;
+  box-shadow: 0 0 0 3px rgba(255, 122, 133, 0.16);
+}

--- a/views/layouts/boilerplate.ejs
+++ b/views/layouts/boilerplate.ejs
@@ -35,6 +35,7 @@
     <script src="https://cdn.lordicon.com/lordicon.js"></script>
     <link rel="stylesheet" href="/css/style.css" />
     <link rel="stylesheet" href="/css/rating.css" />
+    <link rel="stylesheet" href="/css/form-validate.css" />
     <link
       href="https://api.mapbox.com/mapbox-gl-js/v3.3.0/mapbox-gl.css" rel="stylesheet"/>
     <script src="https://api.mapbox.com/mapbox-gl-js/v3.3.0/mapbox-gl.js"></script>
@@ -54,6 +55,7 @@
       crossorigin="anonymous"
     ></script>
 
+    <script src="/JS/form-validate.js"></script>
     <script src="/JS/script.js"></script>
   </body>
 </html>

--- a/views/listings/new.ejs
+++ b/views/listings/new.ejs
@@ -10,6 +10,7 @@
         novalidate
         class="needs-validation"
         enctype="multipart/form-data"
+        data-validate-form
       >
         <div class="mb-3">
           <label for="title" class="form-label">Title : </label>

--- a/views/users/login.ejs
+++ b/views/users/login.ejs
@@ -16,7 +16,7 @@
 <div class="row mt-3" id="login-form">
   <div class="col-12 col-md-6 offset-md-3 mb-4">
     <h2 class="mb-4 mt-2" id="form-head">Welcome Back</h2>
-    <form action="/login" method="POST" novalidate class="needs-validation">
+    <form action="/login" method="POST" novalidate class="needs-validation" data-validate-form>
       <div class="form-floating mb-4">
         <input
           type="text"
@@ -26,7 +26,8 @@
           id="username"
           name="username"
           required
-          required
+          minlength="3"
+          data-validate-message="Username must be at least 3 characters"
         />
         <label for="floatingPassword">Username</label>
       </div>
@@ -39,6 +40,8 @@
           placeholder="Password"
           name="password"
           required
+          minlength="6"
+          data-validate-message="Password must be at least 6 characters"
         />
         <label for="floatingPassword">Password</label>
         <div class="valid-feedback">Looks Good!</div>

--- a/views/users/signup.ejs
+++ b/views/users/signup.ejs
@@ -16,7 +16,7 @@
 <div class="row mt-3">
   <div class="col-12 col-md-6 offset-md-3 mb-4">
     <h2 class="mb-4" id="form-head">Join WanderLust Today</h2>
-    <form action="/signup" method="POST" novalidate class="needs-validation">
+    <form action="/signup" method="POST" novalidate class="needs-validation" data-validate-form>
       <div class="form-floating mb-4">
         <input
           type="text"
@@ -26,6 +26,8 @@
           id="username"
           name="username"
           required
+          minlength="3"
+          data-validate-message="Username must be at least 3 characters"
         />
         <label for="floatingPassword">Username</label>
       </div>
@@ -38,6 +40,7 @@
           name="email"
           placeholder="name@gmail.com"
           required
+          data-validate-message="Enter a valid email address"
         />
         <label for="floatingPassword">E-mail</label>
       </div>
@@ -50,6 +53,8 @@
           placeholder="Password"
           name="password"
           required
+          minlength="6"
+          data-validate-message="Password must be at least 6 characters"
         />
         <label for="floatingPassword">Password</label>
         <div class="valid-feedback">Looks Good!</div>


### PR DESCRIPTION
## Summary
- Adds a small generic validator that activates on \`form[data-validate-form]\`. Reads native HTML5 constraints (\`required\`, \`type=email\`, \`minlength\`, \`min\`, \`pattern\`) and any \`data-validate-message\` overrides.
- Behavior is \"don't yell while I'm typing\": fields are silent until first blur or submit. After that they re-validate on every input.
- Errors render below the field; valid fields get a subtle green border. Submit is blocked until clean and a toast nudges the user; the first bad field is focused.
- Forms wired up: login, signup, new listing.

## Files
- \`public/css/form-validate.css\` (new)
- \`public/JS/form-validate.js\` (new)
- \`views/users/login.ejs\`, \`views/users/signup.ejs\`, \`views/listings/new.ejs\` — opt-in via \`data-validate-form\` + a few attribute hints
- \`views/layouts/boilerplate.ejs\` — wires CSS/JS

## Test plan
- [ ] Open /signup and tab through fields — no errors flash while typing
- [ ] Blur an empty username; error appears
- [ ] Type 2 chars; \"Must be at least 3 characters\" stays. Type a 3rd; error clears, green border appears
- [ ] Try submitting with invalid email — first invalid field focuses, toast shows
- [ ] Toggle dark mode; error colors stay legible