### PR TITLE
feat: booking system with date-range + availability

### DIFF
--- a/app.js
+++ b/app.js
@@ -28,6 +28,7 @@ const reviewRouter = require("./routes/review.js");
 const userRouter = require("./routes/user.js");
 const filterRouter = require("./routes/filter.js");
 const apiRouter = require("./routes/api.js");
+const bookingRouter = require("./routes/booking.js");
 const User = require("./models/user.js");
 const wrapAsyn = require("./utils/wrapAsyn.js");
 const Listing = require("./models/listing.js");
@@ -161,6 +162,7 @@ app.use("/listings/:id/reviews", reviewRouter);
 app.use("/", userRouter);
 app.use("/filter", filterRouter);
 app.use("/api", apiRouter);
+app.use("/", bookingRouter);
 
 /**
  * * Starting Express Server

--- a/models/booking.js
+++ b/models/booking.js
@@ -1,0 +1,73 @@
+/**
+ * * Booking Model Schema
+ * ? Defines the Mongoose schema for guest reservations on listings.
+ * ? Each booking represents a date range [startDate, endDate)
+ * ? where startDate is inclusive and endDate is the checkout day (exclusive).
+ */
+
+const mongoose = require("mongoose");
+const Schema = mongoose.Schema;
+
+const bookingSchema = new Schema({
+  listing: {
+    type: Schema.Types.ObjectId,
+    ref: "Listing",
+    required: true,
+    index: true,
+  },
+  guest: {
+    type: Schema.Types.ObjectId,
+    ref: "User",
+    required: true,
+    index: true,
+  },
+  startDate: {
+    type: Date,
+    required: true,
+  },
+  endDate: {
+    type: Date,
+    required: true,
+  },
+  guests: {
+    type: Number,
+    default: 1,
+    min: 1,
+  },
+  totalPrice: {
+    type: Number,
+    required: true,
+    min: 0,
+  },
+  status: {
+    type: String,
+    enum: ["confirmed", "cancelled"],
+    default: "confirmed",
+  },
+  createdAt: {
+    type: Date,
+    default: Date.now,
+  },
+});
+
+/**
+ * * Compound index for fast overlap queries.
+ */
+bookingSchema.index({ listing: 1, startDate: 1, endDate: 1 });
+
+/**
+ * * Static helper: find any active booking that overlaps the given range.
+ * ? Two ranges [a,b) and [c,d) overlap iff a < d AND b > c.
+ */
+bookingSchema.statics.findOverlapping = function (listingId, start, end) {
+  return this.findOne({
+    listing: listingId,
+    status: "confirmed",
+    startDate: { $lt: end },
+    endDate: { $gt: start },
+  });
+};
+
+const Booking = mongoose.model("Booking", bookingSchema);
+
+module.exports = Booking;

--- a/public/JS/booking.js
+++ b/public/JS/booking.js
@@ -1,0 +1,140 @@
+/**
+ * ! Booking panel client-side script.
+ * * Loads availability ranges via AJAX and prevents picking overlapping dates.
+ * * Computes a live price preview (nights x price) as the user picks dates.
+ */
+(function () {
+  "use strict";
+
+  const panel = document.querySelector("[data-booking-panel]");
+  if (!panel) return;
+
+  const listingId = panel.dataset.listingId;
+  const price = parseFloat(panel.dataset.price || "0");
+  const form = panel.querySelector("[data-booking-form]");
+  if (!form) return;
+
+  const startInput = form.querySelector("[data-booking-start]");
+  const endInput = form.querySelector("[data-booking-end]");
+  const preview = form.querySelector("[data-booking-preview]");
+  const previewText = form.querySelector("[data-booking-preview-text]");
+
+  let bookedRanges = null;
+  let fetchPromise = null;
+
+  function notify(message, type) {
+    if (window.Toast && typeof window.Toast.show === "function") {
+      window.Toast.show(message, type || "error");
+    } else {
+      alert(message);
+    }
+  }
+
+  function fetchAvailability() {
+    if (bookedRanges) return Promise.resolve(bookedRanges);
+    if (fetchPromise) return fetchPromise;
+    fetchPromise = fetch(`/listings/${listingId}/bookings/availability.json`)
+      .then((r) => (r.ok ? r.json() : { ranges: [] }))
+      .then((data) => {
+        bookedRanges = (data.ranges || []).map((r) => ({
+          start: new Date(r.start),
+          end: new Date(r.end),
+        }));
+        return bookedRanges;
+      })
+      .catch(() => {
+        bookedRanges = [];
+        return bookedRanges;
+      });
+    return fetchPromise;
+  }
+
+  function parseDateLocal(s) {
+    if (!s) return null;
+    const d = new Date(s);
+    return Number.isNaN(d.getTime()) ? null : d;
+  }
+
+  function nightsBetween(start, end) {
+    return Math.round((end - start) / (1000 * 60 * 60 * 24));
+  }
+
+  function rangeOverlaps(start, end) {
+    if (!bookedRanges) return false;
+    return bookedRanges.some((r) => start < r.end && end > r.start);
+  }
+
+  function formatINR(amount) {
+    try {
+      return amount.toLocaleString("en-IN");
+    } catch (e) {
+      return String(amount);
+    }
+  }
+
+  function updatePreview() {
+    const start = parseDateLocal(startInput.value);
+    const end = parseDateLocal(endInput.value);
+    if (!start || !end || start >= end) {
+      preview.hidden = true;
+      previewText.textContent = "";
+      return;
+    }
+    const nights = nightsBetween(start, end);
+    const total = nights * price;
+    previewText.textContent = `${nights} night${
+      nights === 1 ? "" : "s"
+    } × ₹${formatINR(price)} = ₹${formatINR(total)}`;
+    preview.hidden = false;
+  }
+
+  function onDateChange() {
+    if (startInput.value) {
+      const next = new Date(startInput.value);
+      next.setDate(next.getDate() + 1);
+      const nextStr = next.toISOString().slice(0, 10);
+      if (!endInput.min || endInput.min < nextStr) {
+        endInput.min = nextStr;
+      }
+      if (endInput.value && endInput.value <= startInput.value) {
+        endInput.value = "";
+      }
+    }
+    fetchAvailability().then(updatePreview);
+  }
+
+  startInput.addEventListener("change", onDateChange);
+  endInput.addEventListener("change", onDateChange);
+
+  form.addEventListener("submit", function (e) {
+    const start = parseDateLocal(startInput.value);
+    const end = parseDateLocal(endInput.value);
+
+    if (!start || !end) {
+      e.preventDefault();
+      notify("Please pick both check-in and check-out dates.", "error");
+      return;
+    }
+    if (start >= end) {
+      e.preventDefault();
+      notify("Check-out must be after check-in.", "error");
+      return;
+    }
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    if (start < today) {
+      e.preventDefault();
+      notify("Check-in cannot be in the past.", "error");
+      return;
+    }
+    if (rangeOverlaps(start, end)) {
+      e.preventDefault();
+      notify(
+        "Those dates overlap an existing booking. Pick another range.",
+        "error"
+      );
+    }
+  });
+
+  fetchAvailability();
+})();

--- a/public/css/booking.css
+++ b/public/css/booking.css
@@ -1,0 +1,293 @@
+/* ! Booking panel + trips page styles
+ * * Uses brand red #fe424d and gradient pinks #e82d72 -> #fe346a -> #ff375f.
+ * * Card radius matches existing 1rem rounded cards.
+ */
+
+.booking-panel {
+  font-family: "Plus Jakarta Sans", system-ui, sans-serif;
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  border-radius: 1rem;
+  padding: 1.25rem 1.25rem 1.5rem;
+  margin: 1.5rem 0;
+  background: #fff;
+  box-shadow: 0 6px 24px rgba(0, 0, 0, 0.06);
+  max-width: 100%;
+}
+
+[data-theme="dark"] .booking-panel {
+  background: #1f1f23;
+  border-color: rgba(255, 255, 255, 0.1);
+  color: #f3f3f3;
+}
+
+.booking-panel__header {
+  display: flex;
+  align-items: baseline;
+  gap: 0.4rem;
+  margin-bottom: 1rem;
+}
+
+.booking-panel__price {
+  font-size: 1.4rem;
+  font-weight: 700;
+  color: #fe424d;
+}
+
+[data-theme="dark"] .booking-panel__price {
+  color: #ff6b73;
+}
+
+.booking-panel__per {
+  font-size: 0.95rem;
+  color: rgba(0, 0, 0, 0.55);
+  font-weight: 500;
+}
+
+[data-theme="dark"] .booking-panel__per {
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.booking-panel__form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.booking-panel__row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.6rem;
+}
+
+.booking-panel__field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.booking-panel__field--full {
+  width: 100%;
+}
+
+.booking-panel__field span {
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-size: 0.72rem;
+  color: rgba(0, 0, 0, 0.6);
+}
+
+[data-theme="dark"] .booking-panel__field span {
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.booking-panel__field input,
+.booking-panel__field select {
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  border-radius: 0.6rem;
+  padding: 0.55rem 0.7rem;
+  font-size: 0.95rem;
+  font-family: inherit;
+  background: #fff;
+  color: inherit;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+[data-theme="dark"] .booking-panel__field input,
+[data-theme="dark"] .booking-panel__field select {
+  background: #2a2a2f;
+  border-color: rgba(255, 255, 255, 0.15);
+  color: #f3f3f3;
+}
+
+.booking-panel__field input:focus,
+.booking-panel__field select:focus {
+  outline: none;
+  border-color: #fe346a;
+  box-shadow: 0 0 0 3px rgba(254, 52, 106, 0.18);
+}
+
+.booking-panel__preview {
+  background: rgba(254, 66, 77, 0.08);
+  border-radius: 0.6rem;
+  padding: 0.6rem 0.8rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #c4253a;
+}
+
+[data-theme="dark"] .booking-panel__preview {
+  background: rgba(254, 52, 106, 0.18);
+  color: #ff8a99;
+}
+
+.booking-panel__cta {
+  background: linear-gradient(90deg, #e82d72, #fe346a, #ff375f);
+  color: #fff;
+  border: none;
+  border-radius: 0.6rem;
+  padding: 0.75rem 1rem;
+  font-size: 1rem;
+  font-weight: 700;
+  cursor: pointer;
+  letter-spacing: 0.02em;
+  transition: transform 0.12s ease, box-shadow 0.12s ease, opacity 0.12s ease;
+  text-align: center;
+  text-decoration: none;
+  display: inline-block;
+}
+
+.booking-panel__cta:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 8px 24px rgba(254, 52, 106, 0.28);
+}
+
+.booking-panel__cta:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
+.booking-panel__cta--link {
+  background: #fe424d;
+}
+
+.booking-panel__note {
+  text-align: center;
+  font-size: 0.78rem;
+  color: rgba(0, 0, 0, 0.5);
+  margin: 0;
+}
+
+[data-theme="dark"] .booking-panel__note {
+  color: rgba(255, 255, 255, 0.55);
+}
+
+/* * Trips page */
+.trips-page {
+  max-width: 960px;
+  margin: 2rem auto;
+  padding: 0 1rem;
+  font-family: "Plus Jakarta Sans", system-ui, sans-serif;
+}
+
+.trips-page__title {
+  font-weight: 700;
+  margin-bottom: 1.25rem;
+  font-size: 1.7rem;
+}
+
+.trips-empty {
+  border: 1px dashed rgba(0, 0, 0, 0.18);
+  border-radius: 1rem;
+  padding: 2rem;
+  text-align: center;
+  color: rgba(0, 0, 0, 0.6);
+}
+
+[data-theme="dark"] .trips-empty {
+  border-color: rgba(255, 255, 255, 0.18);
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.trip-card {
+  display: grid;
+  grid-template-columns: 140px 1fr auto;
+  gap: 1rem;
+  align-items: center;
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  border-radius: 1rem;
+  padding: 1rem;
+  background: #fff;
+  margin-bottom: 1rem;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.04);
+}
+
+[data-theme="dark"] .trip-card {
+  background: #1f1f23;
+  border-color: rgba(255, 255, 255, 0.08);
+}
+
+.trip-card__thumb {
+  width: 140px;
+  height: 100px;
+  border-radius: 0.75rem;
+  object-fit: cover;
+}
+
+.trip-card__title {
+  font-weight: 700;
+  font-size: 1.05rem;
+  margin: 0 0 0.25rem;
+}
+
+.trip-card__meta {
+  margin: 0;
+  font-size: 0.9rem;
+  color: rgba(0, 0, 0, 0.65);
+}
+
+[data-theme="dark"] .trip-card__meta {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.trip-card__total {
+  font-weight: 700;
+  color: #fe424d;
+  margin-top: 0.25rem;
+}
+
+.trip-card__status {
+  display: inline-block;
+  padding: 0.2rem 0.55rem;
+  border-radius: 999px;
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.trip-card__status--confirmed {
+  background: rgba(254, 66, 77, 0.12);
+  color: #c4253a;
+}
+
+.trip-card__status--cancelled {
+  background: rgba(0, 0, 0, 0.08);
+  color: rgba(0, 0, 0, 0.55);
+  text-decoration: line-through;
+}
+
+[data-theme="dark"] .trip-card__status--cancelled {
+  background: rgba(255, 255, 255, 0.1);
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.trip-card__cancel {
+  background: transparent;
+  border: 1px solid #fe424d;
+  color: #fe424d;
+  padding: 0.45rem 0.85rem;
+  border-radius: 0.5rem;
+  font-weight: 600;
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.trip-card__cancel:hover {
+  background: #fe424d;
+  color: #fff;
+}
+
+@media (max-width: 600px) {
+  .trip-card {
+    grid-template-columns: 1fr;
+  }
+  .trip-card__thumb {
+    width: 100%;
+    height: 180px;
+  }
+}

--- a/routes/booking.js
+++ b/routes/booking.js
@@ -1,0 +1,172 @@
+/**
+ * ! Routes for booking creation, listing trips, cancellation, and availability lookups.
+ */
+
+const express = require("express");
+const router = express.Router({ mergeParams: true });
+
+const Listing = require("../models/listing.js");
+const Booking = require("../models/booking.js");
+const wrapAsync = require("../utils/wrapAsyn.js");
+const { isLoggedIn } = require("../middleware.js");
+
+/**
+ * * Helper: parse a YYYY-MM-DD date string as a UTC midnight Date.
+ */
+function parseDate(value) {
+  if (!value) return null;
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return null;
+  return d;
+}
+
+/**
+ * * Helper: number of nights between two midnights.
+ */
+function nightsBetween(start, end) {
+  const ms = end.getTime() - start.getTime();
+  return Math.round(ms / (1000 * 60 * 60 * 24));
+}
+
+/**
+ * * POST /listings/:id/bookings
+ * ? Creates a new booking for the current user.
+ */
+router.post(
+  "/listings/:id/bookings",
+  isLoggedIn,
+  wrapAsync(async (req, res) => {
+    const { id } = req.params;
+    const { startDate, endDate, guests } = req.body;
+
+    const listing = await Listing.findById(id);
+    if (!listing) {
+      req.flash("error", "Listing not found");
+      return res.redirect("/listings");
+    }
+
+    const start = parseDate(startDate);
+    const end = parseDate(endDate);
+
+    if (!start || !end) {
+      req.flash("error", "Please select valid check-in and check-out dates");
+      return res.redirect(`/listings/${id}`);
+    }
+
+    if (start >= end) {
+      req.flash("error", "Check-out must be after check-in");
+      return res.redirect(`/listings/${id}`);
+    }
+
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    if (start < today) {
+      req.flash("error", "Check-in cannot be in the past");
+      return res.redirect(`/listings/${id}`);
+    }
+
+    const overlap = await Booking.findOverlapping(id, start, end);
+    if (overlap) {
+      req.flash(
+        "error",
+        "Sorry, those dates overlap with an existing booking. Please pick another range."
+      );
+      return res.redirect(`/listings/${id}`);
+    }
+
+    const nights = nightsBetween(start, end);
+    const guestsCount = Math.max(1, parseInt(guests, 10) || 1);
+    const totalPrice = nights * (listing.price || 0);
+
+    await Booking.create({
+      listing: listing._id,
+      guest: req.user._id,
+      startDate: start,
+      endDate: end,
+      guests: guestsCount,
+      totalPrice,
+      status: "confirmed",
+    });
+
+    req.flash(
+      "success",
+      `Booking confirmed for ${nights} night${nights === 1 ? "" : "s"}!`
+    );
+    res.redirect("/me/trips");
+  })
+);
+
+/**
+ * * GET /me/trips
+ * ? Lists the current user's bookings as guest.
+ */
+router.get(
+  "/me/trips",
+  isLoggedIn,
+  wrapAsync(async (req, res) => {
+    const trips = await Booking.find({ guest: req.user._id })
+      .populate("listing")
+      .sort({ startDate: -1 });
+    res.render("bookings/trips.ejs", { trips });
+  })
+);
+
+/**
+ * * POST /bookings/:id/cancel
+ * ? Cancels a booking owned by the current user.
+ */
+router.post(
+  "/bookings/:id/cancel",
+  isLoggedIn,
+  wrapAsync(async (req, res) => {
+    const { id } = req.params;
+    const booking = await Booking.findById(id);
+    if (!booking) {
+      req.flash("error", "Booking not found");
+      return res.redirect("/me/trips");
+    }
+    if (!booking.guest.equals(req.user._id)) {
+      req.flash("error", "You can only cancel your own bookings");
+      return res.redirect("/me/trips");
+    }
+    if (booking.status !== "confirmed") {
+      req.flash("error", "Booking is already cancelled");
+      return res.redirect("/me/trips");
+    }
+    booking.status = "cancelled";
+    await booking.save();
+    req.flash("success", "Booking cancelled");
+    res.redirect("/me/trips");
+  })
+);
+
+/**
+ * * GET /listings/:id/bookings/availability.json
+ * ? Returns booked ranges for a listing as JSON.
+ */
+router.get(
+  "/listings/:id/bookings/availability.json",
+  wrapAsync(async (req, res) => {
+    const { id } = req.params;
+    const { from, to } = req.query;
+
+    const filter = { listing: id, status: "confirmed" };
+    const fromDate = parseDate(from);
+    const toDate = parseDate(to);
+    if (fromDate && toDate) {
+      filter.startDate = { $lt: toDate };
+      filter.endDate = { $gt: fromDate };
+    }
+
+    const bookings = await Booking.find(filter).select(
+      "startDate endDate -_id"
+    );
+    const ranges = bookings.map((b) => ({
+      start: b.startDate.toISOString().slice(0, 10),
+      end: b.endDate.toISOString().slice(0, 10),
+    }));
+    res.json({ listing: id, ranges });
+  })
+);
+
+module.exports = router;

--- a/views/bookings/trips.ejs
+++ b/views/bookings/trips.ejs
@@ -1,0 +1,87 @@
+<% layout("layouts/boilerplate") -%>
+<link rel="stylesheet" href="/css/booking.css" />
+
+<%
+  function fmt(d) {
+    if (!d) return "";
+    try {
+      return new Date(d).toLocaleDateString("en-IN", {
+        day: "numeric",
+        month: "short",
+        year: "numeric",
+      });
+    } catch (e) {
+      return new Date(d).toDateString();
+    }
+  }
+  function nights(start, end) {
+    const ms = new Date(end).getTime() - new Date(start).getTime();
+    return Math.max(1, Math.round(ms / (1000 * 60 * 60 * 24)));
+  }
+%>
+
+<section class="trips-page">
+  <h2 class="trips-page__title">My trips</h2>
+
+  <% if (!trips || trips.length === 0) { %>
+    <div class="trips-empty">
+      <p>You haven't booked anything yet.</p>
+      <a href="/listings" class="booking-panel__cta" style="margin-top: 0.75rem;">
+        Browse listings
+      </a>
+    </div>
+  <% } else { %>
+    <% trips.forEach(function(trip) { %>
+      <% const l = trip.listing; %>
+      <article class="trip-card">
+        <% if (l && l.image && l.image.url) { %>
+          <a href="/listings/<%= l._id %>">
+            <img
+              src="<%= l.image.url %>"
+              alt="<%= l.title %>"
+              class="trip-card__thumb"
+            />
+          </a>
+        <% } else { %>
+          <div class="trip-card__thumb" style="background: rgba(0,0,0,0.06);"></div>
+        <% } %>
+
+        <div>
+          <h3 class="trip-card__title">
+            <% if (l) { %>
+              <a href="/listings/<%= l._id %>" style="color: inherit; text-decoration: none;">
+                <%= l.title %>
+              </a>
+            <% } else { %>
+              Listing unavailable
+            <% } %>
+          </h3>
+          <p class="trip-card__meta">
+            <% if (l && l.location) { %><%= l.location %> &middot; <% } %>
+            <%= fmt(trip.startDate) %> &rarr; <%= fmt(trip.endDate) %>
+            (<%= nights(trip.startDate, trip.endDate) %> night<%= nights(trip.startDate, trip.endDate) === 1 ? "" : "s" %>)
+          </p>
+          <p class="trip-card__meta">
+            <%= trip.guests %> guest<%= trip.guests === 1 ? "" : "s" %>
+          </p>
+          <p class="trip-card__total">
+            Total: &#8377;<%= (trip.totalPrice || 0).toLocaleString("en-IN") %>
+          </p>
+          <span class="trip-card__status trip-card__status--<%= trip.status %>">
+            <%= trip.status %>
+          </span>
+        </div>
+
+        <% if (trip.status === "confirmed") { %>
+          <form action="/bookings/<%= trip._id %>/cancel" method="POST">
+            <button type="submit" class="trip-card__cancel">
+              Cancel
+            </button>
+          </form>
+        <% } else { %>
+          <span></span>
+        <% } %>
+      </article>
+    <% }); %>
+  <% } %>
+</section>

--- a/views/includes/bookingPanel.ejs
+++ b/views/includes/bookingPanel.ejs
@@ -1,0 +1,68 @@
+<link rel="stylesheet" href="/css/booking.css" />
+<%
+  const today = new Date();
+  const todayStr = today.toISOString().slice(0, 10);
+  const tomorrow = new Date(today.getTime() + 24 * 60 * 60 * 1000);
+  const tomorrowStr = tomorrow.toISOString().slice(0, 10);
+%>
+<aside class="booking-panel" data-booking-panel data-listing-id="<%= listing._id %>" data-price="<%= listing.price %>">
+  <div class="booking-panel__header">
+    <span class="booking-panel__price">
+      &#8377;<%= listing.price.toLocaleString("en-IN") %>
+    </span>
+    <span class="booking-panel__per">/ night</span>
+  </div>
+
+  <% if (currUser) { %>
+    <form
+      action="/listings/<%= listing._id %>/bookings"
+      method="POST"
+      class="booking-panel__form"
+      data-booking-form
+      novalidate
+    >
+      <div class="booking-panel__row">
+        <label class="booking-panel__field">
+          <span>Check-in</span>
+          <input
+            type="date"
+            name="startDate"
+            min="<%= todayStr %>"
+            required
+            data-booking-start
+          />
+        </label>
+        <label class="booking-panel__field">
+          <span>Check-out</span>
+          <input
+            type="date"
+            name="endDate"
+            min="<%= tomorrowStr %>"
+            required
+            data-booking-end
+          />
+        </label>
+      </div>
+      <label class="booking-panel__field booking-panel__field--full">
+        <span>Guests</span>
+        <select name="guests" data-booking-guests>
+          <% for (let g = 1; g <= 8; g++) { %>
+            <option value="<%= g %>"><%= g %> guest<%= g === 1 ? '' : 's' %></option>
+          <% } %>
+        </select>
+      </label>
+
+      <div class="booking-panel__preview" data-booking-preview hidden>
+        <span data-booking-preview-text></span>
+      </div>
+
+      <button type="submit" class="booking-panel__cta">Reserve</button>
+      <p class="booking-panel__note">You won't be charged yet.</p>
+    </form>
+  <% } else { %>
+    <a class="booking-panel__cta booking-panel__cta--link" href="/login">
+      Log in to reserve
+    </a>
+  <% } %>
+</aside>
+<script src="/JS/booking.js"></script>

--- a/views/includes/navbar.ejs
+++ b/views/includes/navbar.ejs
@@ -159,6 +159,7 @@ c201 -48 366 -92 368 -97 2 -5 -78 -50 -177 -99 -166 -82 -182 -89 -203 -76
   <a class="nav-link" href="/signup">Sign Up</a>
   <a class="nav-link" href="/login">Log In</a>
   <%} %> <% if(currUser){%>
+  <a class="nav-link" href="/me/trips">My trips</a>
   <a class="nav-link" href="/logout">Log Out</a>
   <a class="nav-link" href="/wishlists">Wishlist</a>
   <%} %>

--- a/views/listings/show.ejs
+++ b/views/listings/show.ejs
@@ -113,6 +113,8 @@
             <% } %>
           <% } %>
 
+          <%- include("../includes/bookingPanel.ejs") %>
+
           <hr />
 
           <% if (averageRating === 5) { %>


### PR DESCRIPTION
## Summary

Adds a complete booking flow on top of the existing listing pages, including a date-range reservation panel on the show page, availability checks against overlapping bookings, a "My trips" page for guests, and cancel support.

Closes #14

## What's new

- **`models/booking.js`** — new Mongoose model with `listing`, `guest`, `startDate` (inclusive), `endDate` (exclusive), `guests`, `totalPrice`, `status` (`confirmed`/`cancelled`), `createdAt`. Compound index `{listing, startDate, endDate}` for fast overlap queries. Static `Booking.findOverlapping(listingId, start, end)` returns any active booking where `startDate < end` AND `endDate > start`.
- **`routes/booking.js`** mounted in `app.js`:
  - `POST /listings/:id/bookings` (auth) — validates dates, computes `nights x listing.price`, rejects past dates / inverted ranges / overlaps, creates booking, redirects to `/me/trips`.
  - `GET /me/trips` (auth) — guest's bookings populated with listing.
  - `POST /bookings/:id/cancel` (auth, must be guest) — sets `status=cancelled`.
  - `GET /listings/:id/bookings/availability.json` — returns booked ranges as JSON for the picker.
- **`views/includes/bookingPanel.ejs`** — drop-in partial with native `<input type="date">` (min today), guests select, "Reserve" button. One include line was added to `views/listings/show.ejs` near the price block.
- **`public/JS/booking.js`** — fetches availability once per page, live-updates "X nights × ₹Y = ₹Z" preview, blocks submission when the chosen range overlaps a booked range (Toast error).
- **`public/css/booking.css`** — new stylesheet only; preserves brand red `#fe424d`, gradient pinks `#e82d72/#fe346a/#ff375f`, Plus Jakarta Sans, and 1rem rounded cards. No existing CSS files were edited.
- **`views/bookings/trips.ejs`** — card list with thumbnail, dates, nights, total, status pill, and a Cancel button when confirmed.
- **`views/includes/navbar.ejs`** — adds "My trips" link inside `.user-toggle` dropdown above "Log Out".

## Test plan

- [ ] Open any listing as a logged-in user, pick a check-in and check-out — verify the live "N nights × ₹price = ₹total" preview appears under the date inputs.
- [ ] Submit a valid range — confirm redirect to `/me/trips` and a success flash, with the new booking visible.
- [ ] Open the same listing in a second browser/account and try to book an overlapping range — confirm rejection (server flash + client-side toast). Trying `start === end` or a past date should also be rejected.
- [ ] On `/me/trips` click "Cancel" on a confirmed booking — verify it flips to `cancelled` and the cancel button disappears; re-booking the now-free dates from another account succeeds.
- [ ] Hit `GET /listings/<id>/bookings/availability.json` directly and confirm it returns `{ listing, ranges: [{start, end}, ...] }` for confirmed bookings only (cancelled ones should not appear).
- [ ] Logged-out users on the show page see a "Log in to reserve" CTA instead of the form.