### PR TITLE
feat: 5-step listing creation/edit wizard

### DIFF
--- a/controller/listings.js
+++ b/controller/listings.js
@@ -116,6 +116,20 @@ module.exports.createListing = async (req, res, next) => {
   newListing.typeOfPlace = req.body.listing.typeOfPlace;
   newListing.bedrooms = req.body.listing.bedrooms;
   newListing.beds = req.body.listing.beds;
+  newListing.bathrooms = req.body.listing.bathrooms;
+  newListing.maxGuests = req.body.listing.maxGuests;
+
+  // Normalize amenities (array of strings, trim, drop empties)
+  let amenitiesInput = req.body.listing.amenities;
+  if (typeof amenitiesInput === "string") {
+    amenitiesInput = amenitiesInput
+      ? amenitiesInput.split(",").map((s) => s.trim())
+      : [];
+  }
+  newListing.amenities = Array.isArray(amenitiesInput)
+    ? amenitiesInput.map((a) => String(a).trim()).filter(Boolean)
+    : [];
+
   newListing.locked = req.body.listing.locked;
   newListing.other = req.body.listing.other;
   let savedListing = await newListing.save();
@@ -153,11 +167,19 @@ module.exports.renderEditForm = async (req, res) => {
 module.exports.updateListing = async (req, res) => {
   let { id } = req.params;
 
-  let listing = await Listing.findByIdAndUpdate(
-    id,
-    { ...req.body.listing },
-    { new: true }
-  );
+  // Normalize amenities (array of strings, trim, drop empties)
+  let payload = { ...req.body.listing };
+  let amenitiesInput = payload.amenities;
+  if (typeof amenitiesInput === "string") {
+    amenitiesInput = amenitiesInput
+      ? amenitiesInput.split(",").map((s) => s.trim())
+      : [];
+  }
+  payload.amenities = Array.isArray(amenitiesInput)
+    ? amenitiesInput.map((a) => String(a).trim()).filter(Boolean)
+    : [];
+
+  let listing = await Listing.findByIdAndUpdate(id, payload, { new: true });
 
   if (typeof req.file !== "undefined") {
     let url = req.file.path;

--- a/models/listing.js
+++ b/models/listing.js
@@ -93,6 +93,20 @@ const listingSchema = Schema({
     type: Number,
     max: 8,
   },
+  bathrooms: {
+    type: Number,
+    max: 8,
+  },
+  maxGuests: {
+    type: Number,
+    max: 16,
+    default: 2,
+  },
+  amenities: [
+    {
+      type: String,
+    },
+  ],
   locked: {
     type: String,
     enum: ["yes", "no"],

--- a/public/JS/wizard.js
+++ b/public/JS/wizard.js
@@ -1,0 +1,131 @@
+/* 5-step listing wizard
+ *  - Steps are <section class="wizard-step" data-step="N">
+ *  - The first step is shown by default; subsequent steps are revealed on Next.
+ *  - Next is disabled until the current step's required fields pass HTML5 validity.
+ *  - On the final step, the form's normal POST submit fires.
+ */
+(function () {
+  const wizard = document.querySelector("[data-wizard]");
+  if (!wizard) return;
+
+  const form = wizard.closest("form");
+  const steps = Array.from(wizard.querySelectorAll(".wizard-step"));
+  const dots = Array.from(wizard.querySelectorAll(".wizard-dot"));
+  const counterEl = wizard.querySelector(".wizard-step-counter");
+  const btnNext = wizard.querySelector("[data-wizard-next]");
+  const btnBack = wizard.querySelector("[data-wizard-back]");
+  const btnSubmit = wizard.querySelector("[data-wizard-submit]");
+
+  let current = 0;
+
+  function getRequiredFields(stepEl) {
+    return Array.from(
+      stepEl.querySelectorAll("input, select, textarea")
+    ).filter(
+      (el) =>
+        el.hasAttribute("required") &&
+        !el.disabled &&
+        el.type !== "hidden" &&
+        el.offsetParent !== null
+    );
+  }
+
+  function isStepValid(stepEl) {
+    const fields = getRequiredFields(stepEl);
+    return fields.every((el) => el.checkValidity());
+  }
+
+  function setActive(idx) {
+    current = Math.max(0, Math.min(idx, steps.length - 1));
+    steps.forEach((s, i) => {
+      if (i === current) s.setAttribute("data-active", "");
+      else s.removeAttribute("data-active");
+    });
+    dots.forEach((d, i) => {
+      d.classList.toggle("is-active", i === current);
+      d.classList.toggle("is-complete", i < current);
+    });
+    if (counterEl) {
+      counterEl.textContent =
+        "Step " + (current + 1) + " of " + steps.length;
+    }
+    btnBack.style.visibility = current === 0 ? "hidden" : "visible";
+    if (current === steps.length - 1) {
+      btnNext.style.display = "none";
+      btnSubmit.style.display = "inline-block";
+    } else {
+      btnNext.style.display = "inline-block";
+      btnSubmit.style.display = "none";
+    }
+    refreshNext();
+  }
+
+  function refreshNext() {
+    const ok = isStepValid(steps[current]);
+    if (btnNext.style.display !== "none") btnNext.disabled = !ok;
+    if (btnSubmit && current === steps.length - 1) {
+      btnSubmit.disabled = !ok;
+    }
+  }
+
+  function bindLiveValidation() {
+    steps.forEach((s) => {
+      s.addEventListener("input", refreshNext, true);
+      s.addEventListener("change", refreshNext, true);
+    });
+  }
+
+  btnNext.addEventListener("click", function (e) {
+    e.preventDefault();
+    if (!isStepValid(steps[current])) {
+      // Focus first invalid
+      const fields = getRequiredFields(steps[current]);
+      const bad = fields.find((el) => !el.checkValidity());
+      if (bad) bad.reportValidity();
+      return;
+    }
+    setActive(current + 1);
+    wizard.scrollIntoView({ behavior: "smooth", block: "start" });
+  });
+
+  btnBack.addEventListener("click", function (e) {
+    e.preventDefault();
+    setActive(current - 1);
+    wizard.scrollIntoView({ behavior: "smooth", block: "start" });
+  });
+
+  // File upload visual feedback
+  const fileInput = wizard.querySelector('input[type="file"]');
+  if (fileInput) {
+    fileInput.addEventListener("change", function () {
+      const zone = fileInput.closest(".upload-zone");
+      const span = wizard.querySelector("[data-upload-text]");
+      if (this.files && this.files.length > 0) {
+        if (zone) zone.classList.add("has-file");
+        if (span) {
+          span.textContent = "Image ready: " + this.files[0].name;
+          span.style.color = "#4BB543";
+        }
+      }
+    });
+  }
+
+  // Form submit guard: ensure all steps validate.
+  if (form) {
+    form.addEventListener("submit", function (e) {
+      for (let i = 0; i < steps.length; i++) {
+        if (!isStepValid(steps[i])) {
+          e.preventDefault();
+          setActive(i);
+          const fields = getRequiredFields(steps[i]);
+          const bad = fields.find((el) => !el.checkValidity());
+          if (bad) bad.reportValidity();
+          return;
+        }
+      }
+    });
+  }
+
+  bindLiveValidation();
+  setActive(0);
+})();

--- a/public/css/wizard.css
+++ b/public/css/wizard.css
@@ -1,0 +1,240 @@
+/* Wizard styles for 5-step listing form */
+.wizard {
+  max-width: 760px;
+  margin: 0 auto;
+  padding: 1.5rem 1rem 3rem;
+}
+
+.wizard-progress {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.6rem;
+  margin: 0.5rem 0 1.75rem;
+}
+
+.wizard-dot {
+  width: 0.7rem;
+  height: 0.7rem;
+  border-radius: 50%;
+  background: #e6e6e6;
+  border: 2px solid transparent;
+  transition: transform 0.25s ease, background 0.25s ease, border-color 0.25s ease;
+}
+
+.wizard-dot.is-active {
+  background: #fe424d;
+  transform: scale(1.25);
+}
+
+.wizard-dot.is-complete {
+  background: #fe424d;
+  opacity: 0.55;
+}
+
+.wizard-step-counter {
+  text-align: center;
+  font-weight: 600;
+  color: #6b6b6b;
+  font-size: 0.9rem;
+  margin-bottom: 0.4rem;
+  font-family: "Plus Jakarta Sans", sans-serif;
+}
+
+.wizard-step {
+  display: none;
+  animation: wl-fade 0.28s ease both;
+  background: var(--card-bg, #fff);
+  border-radius: 1rem;
+  padding: 1.5rem;
+  box-shadow: 0 6px 22px rgba(0, 0, 0, 0.05);
+}
+
+.wizard-step[data-active] {
+  display: block;
+}
+
+@keyframes wl-fade {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.wizard-step h4 {
+  margin: 0 0 0.35rem;
+  font-weight: 700;
+  font-family: "Plus Jakarta Sans", sans-serif;
+}
+
+.wizard-step .wizard-hint {
+  color: #777;
+  margin-bottom: 1.1rem;
+  font-size: 0.95rem;
+}
+
+.wizard-actions {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 1.5rem;
+  gap: 0.75rem;
+}
+
+.wizard-btn {
+  border-radius: 999px;
+  padding: 0.65rem 1.4rem;
+  font-weight: 600;
+  border: 1px solid #ddd;
+  background: #fff;
+  color: #222;
+  cursor: pointer;
+  transition: transform 0.15s ease, opacity 0.2s ease, background 0.2s;
+  font-family: "Plus Jakarta Sans", sans-serif;
+}
+
+.wizard-btn:hover:not(:disabled) {
+  transform: translateY(-1px);
+}
+
+.wizard-btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.wizard-btn-primary {
+  background: linear-gradient(135deg, #fe424d 0%, #ff7a85 100%);
+  color: #fff;
+  border: none;
+}
+
+.wizard-btn-primary:hover:not(:disabled) {
+  background: linear-gradient(135deg, #e63946 0%, #ff6373 100%);
+}
+
+/* Amenities grid */
+.amenity-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  gap: 0.65rem;
+}
+
+.amenity-item {
+  position: relative;
+  display: block;
+}
+
+.amenity-item input[type="checkbox"] {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.amenity-item .amenity-tile {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.7rem 0.85rem;
+  border: 1.5px solid #e2e2e2;
+  border-radius: 0.85rem;
+  cursor: pointer;
+  transition: border-color 0.2s ease, background 0.2s ease, transform 0.15s ease;
+  font-weight: 500;
+  font-size: 0.92rem;
+  background: var(--input-bg, #fff);
+  color: var(--text, #222);
+}
+
+.amenity-item input[type="checkbox"]:checked + .amenity-tile {
+  border-color: #fe424d;
+  background: rgba(254, 66, 77, 0.07);
+  color: #fe424d;
+}
+
+.amenity-item .amenity-tile:hover {
+  transform: translateY(-1px);
+}
+
+/* Generic step grid */
+.wizard-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+}
+
+@media (max-width: 600px) {
+  .wizard-row {
+    grid-template-columns: 1fr;
+  }
+}
+
+.wizard-step .form-control,
+.wizard-step .form-select {
+  border-radius: 0.6rem;
+}
+
+[data-theme="dark"] .wizard-step {
+  background: #1f1f1f;
+}
+
+[data-theme="dark"] .wizard-btn {
+  background: #2a2a2a;
+  color: #f0f0f0;
+  border-color: #3a3a3a;
+}
+
+[data-theme="dark"] .amenity-item .amenity-tile {
+  background: #2a2a2a;
+  border-color: #3a3a3a;
+  color: #f0f0f0;
+}
+
+[data-theme="dark"] .amenity-item input[type="checkbox"]:checked + .amenity-tile {
+  background: rgba(254, 66, 77, 0.15);
+  color: #ff7a85;
+  border-color: #fe424d;
+}
+
+[data-theme="dark"] .wizard-dot {
+  background: #444;
+}
+
+.upload-zone {
+  border: 2px dashed #d8d8d8;
+  border-radius: 1rem;
+  padding: 2rem 1rem;
+  text-align: center;
+  cursor: pointer;
+  transition: border-color 0.2s ease, background 0.2s ease;
+}
+
+.upload-zone:hover {
+  border-color: #fe424d;
+  background: rgba(254, 66, 77, 0.04);
+}
+
+.upload-zone.has-file {
+  border-color: #4bb543;
+  background: rgba(75, 181, 67, 0.05);
+}
+
+.upload-zone input[type="file"] {
+  display: none;
+}
+
+.upload-zone .upload-text {
+  font-weight: 600;
+  color: #555;
+}
+
+[data-theme="dark"] .upload-zone {
+  border-color: #444;
+}
+
+[data-theme="dark"] .upload-zone .upload-text {
+  color: #ccc;
+}

--- a/schema.js
+++ b/schema.js
@@ -18,6 +18,11 @@ module.exports.listingSchema = Joi.object({
     typeOfPlace: Joi.string().required(),
     bedrooms: Joi.number().required().max(8),
     beds: Joi.number().required().max(8),
+    bathrooms: Joi.number().max(8).optional().allow("", null),
+    maxGuests: Joi.number().max(16).optional().allow("", null),
+    amenities: Joi.alternatives()
+      .try(Joi.array().items(Joi.string().allow("")), Joi.string().allow(""))
+      .optional(),
     locked: Joi.string().required(),
     other: Joi.string().required(),
   }).required(),

--- a/views/listings/editForm.ejs
+++ b/views/listings/editForm.ejs
@@ -1,204 +1,175 @@
-
 <% layout("layouts/boilerplate") -%>
 <link rel="stylesheet" href="/css/new.css" />
+<link rel="stylesheet" href="/css/wizard.css" />
+
+<%
+  const AMENITIES = ['Wifi','Kitchen','Parking','Pool','AC','Heating','Washer','Hot tub','Workspace','BBQ','Beachfront','Pet-friendly'];
+  const CATEGORIES = ['trending','beach','arctic','outside','iconic-city','castles','pool','camping','cabin','farms','mountain','domes','boats','tropical','windmill','ski','chef','disabled','play'];
+  const existingAmenities = (listing.amenities || []).map(a => String(a));
+%>
+
 <body>
-  <div class="row mt-3">
-    <div class="col-12 col-md-8 offset-md-2">
-      <h3>Edit Form</h3>
-      <form
-        method="POST"
-        action="/listings/<%=listing._id%>?_method=PUT"
-        novalidate
-        class="needs-validation"
-        enctype="multipart/form-data"
-      >
-        <div class="mb-3">
-          <label for="title" class="form-label">Title : </label>
-          <input
-            type="text"
-            class="form-control"
-            id="title"
-            name="listing[title]"
-            placeholder="Listing Title"
-            value="<%=listing.title%>"
-            required
-          />
-          <div class="valid-feedback">Title looks Good</div>
-        </div>
-        <div class="mb-3">
-          <label for="description" class="form-label">Description : </label>
-          <textarea
-            type="text"
-            class="form-control"
-            id="description"
-            name="listing[description]"
-            required
-          >
-            <%=listing.description%></textarea
-          >
-          <div class="invalid-feedback">Please enter a short description</div>
-        </div>
-        <div class="row">
-          <p>Original Image</p>
-        <div class="mb-3 col-md-4">
-          <img src="<%=originalImageUrl %>" alt="" />
-        </div>
-
-        <div class="mb-3 col-md-8">
-          <label class="custum-file-upload" for="file">
-            <div class="icon">
-            <svg xmlns="http://www.w3.org/2000/svg" fill="" viewBox="0 0 24 24"><g stroke-width="0" id="SVGRepo_bgCarrier"></g><g stroke-linejoin="round" stroke-linecap="round" id="SVGRepo_tracerCarrier"></g><g id="SVGRepo_iconCarrier"> <path fill="" d="M10 1C9.73478 1 9.48043 1.10536 9.29289 1.29289L3.29289 7.29289C3.10536 7.48043 3 7.73478 3 8V20C3 21.6569 4.34315 23 6 23H7C7.55228 23 8 22.5523 8 22C8 21.4477 7.55228 21 7 21H6C5.44772 21 5 20.5523 5 20V9H10C10.5523 9 11 8.55228 11 8V3H18C18.5523 3 19 3.44772 19 4V9C19 9.55228 19.4477 10 20 10C20.5523 10 21 9.55228 21 9V4C21 2.34315 19.6569 1 18 1H10ZM9 7H6.41421L9 4.41421V7ZM14 15.5C14 14.1193 15.1193 13 16.5 13C17.8807 13 19 14.1193 19 15.5V16V17H20C21.1046 17 22 17.8954 22 19C22 20.1046 21.1046 21 20 21H13C11.8954 21 11 20.1046 11 19C11 17.8954 11.8954 17 13 17H14V16V15.5ZM16.5 11C14.142 11 12.2076 12.8136 12.0156 15.122C10.2825 15.5606 9 17.1305 9 19C9 21.2091 10.7909 23 13 23H20C22.2091 23 24 21.2091 24 19C24 17.1305 22.7175 15.5606 20.9844 15.122C20.7924 12.8136 18.858 11 16.5 11Z" clip-rule="evenodd" fill-rule="evenodd"></path> </g></svg>
-            </div>
-            <div class="text">
-               <span id="uploadText">Click to upload image</span>
-               </div>
-               <input type="file" id="file" name="listing[image]" class="form-control">
-            </label>
-            
-        </div>
-        </div>
-
-        <div class="row">
-          <div class="mb-3 col-md-8">
-            <label for="price" class="form-label">Price : </label>
-            <input
-              type="number"
-              class="form-control"
-              id="price"
-              name="listing[price]"
-              placeholder="1200"
-              value="<%=listing.price%>"
-              required
-            />
-            <div class="invalid-feedback">Price should be valid</div>
-          </div>
-          <div class="mb-2 col-md-4">
-            <label for="select-styling" id="label">Catogery :</label>
-          <select
-            class="custom-select form-select"
-            id="select-styling"
-            placeholder="Choose"
-            name="listing[category]"
-            class="form-control"
-          >
-          <% const categories = ['trending', 'beach', 'arctic', 'outside', 'iconic-city', 'castles', 'pool', 'camping', 'cabin', 'farms', 'mountain', 'domes', 'boats', 'tropical', 'windmill', 'ski', 'chef', 'disabled', 'play']; %>
-          <% categories.forEach(cat => { %>
-            <option value="<%= cat %>" <%= listing.category === cat ? 'selected' : '' %>><%= cat.charAt(0).toUpperCase() + cat.slice(1) %></option>
-          <% }); %>
-       
-          </select>
-          </div>
-        </div>
-        <div class="row">
-          <div class="mb-3 col-md-4">
-            <label for="location" class="form-label">Location : </label>
-            <input
-              type="text"
-              class="form-control"
-              id="location"
-              name="listing[location]"
-              placeholder="Indore,Madhya Pradesh"
-              value="<%=listing.location%>"
-              required
-            />
-            <div class="invalid-feedback">Location should be valid</div>
-          </div>
-          <div class="col-md-8 mb-3 select-label">
-            <label for="country" class="form-label">Country : </label>
-              <input
-                type="text"
-                class="form-control"
-                id="country"
-                name="listing[country]"
-                placeholder="India"
-                value="<%=listing.country%>"
-                required
-              />
-              <div class="invalid-feedback">Country name should be valid</div>
-          </div>
-  
-        </div>
- <!-- Bedrooms and Beds -->
-       <div class="row mb-3">
-        <div class="col-md-6">
-          <label for="bedrooms" class="form-label">Bedrooms:</label>
-        <input type="number" id="bedrooms" name="listing[bedrooms]" value="<%=listing.bedrooms%>" class="form-control" required />
-        </div>
-
-       <div class="col-md-6">
-        <label for="beds" class="form-label">Beds:</label>
-        <input type="number" id="beds" name="listing[beds]" value="<%=listing.beds%>" class="form-control" required />
-       </div>
-       </div>
-
-       <div class="row">
-        <div class="col-md-4">
-          <label for="select-styling form-select" id="label">Type Of Place :</label>
-        <select
-          class="custom-select form-select"
-          id="select-styling"
-          placeholder="Choose"
-          name="listing[typeOfPlace]"
-          class="form-control"
-        >
-        <option value="entire-place" <%= listing.typeOfPlace === 'entire-place' ? 'selected' : '' %>>Entire Place</option>
-        <option value="room" <%= listing.typeOfPlace === 'room' ? 'selected' : '' %>>Room</option>
-        <option value="shared-room" <%= listing.typeOfPlace === 'shared-room' ? 'selected' : '' %>>Shared Room</option>
-        </select>
-        </div>
-       
-
-        <div class="col-md-4">
-          <label for="room-locked" id="label">Room Locked :</label>
-        <select
-          class="custom-select form-select"
-          id="room-locked"
-          placeholder="Choose"
-          name="listing[locked]"
-          class="form-control"
-        >
-        <option value="yes" <%= listing.locked === 'yes' ? 'selected' : '' %>>Yes</option>
-        <option value="no" <%= listing.locked === 'no'
-
- ? 'selected' : '' %>>No</option>
-        </select>
-        </div>
-
-      <div class="col-md-4">
-        <label for="someone" id="label">Is There Someone Else :</label>
-        <select
-          class="custom-select form-select"
-          id="someone"
-          placeholder="Choose"
-          name="listing[other]"
-          class="form-control"
-        >
-        <option value="no" <%= listing.other === 'no' ? 'selected' : '' %>>No</option>
-        <option value="me" <%= listing.other === 'me' ? 'selected' : '' %>>Me</option>
-        <option value="family" <%= listing.other === 'family' ? 'selected' : '' %>>Family</option>
-        <option value="other-guests" <%= listing.other === 'other-guests' ? 'selected' : '' %>>Other Guest</option>
-        </select>
-      </div>
-       </div>
-      </div>
-      </div>
-     
-        <button class="btn offset-md-2 edit-button"><span>Submit</span></button>
-      </form>
-      <br>
-      <br>
-      <br>
-      <br>
+  <div class="wizard" data-wizard>
+    <h3 class="text-center mb-1">Edit Listing</h3>
+    <div class="wizard-step-counter">Step 1 of 5</div>
+    <div class="wizard-progress" aria-hidden="true">
+      <span class="wizard-dot"></span>
+      <span class="wizard-dot"></span>
+      <span class="wizard-dot"></span>
+      <span class="wizard-dot"></span>
+      <span class="wizard-dot"></span>
     </div>
+
+    <form
+      method="POST"
+      action="/listings/<%= listing._id %>?_method=PUT"
+      novalidate
+      class="needs-validation"
+      enctype="multipart/form-data"
+    >
+      <!-- Step 1: Place type & basics -->
+      <section class="wizard-step" data-step="1" data-active>
+        <h4>About your place</h4>
+        <p class="wizard-hint">Update the basics.</p>
+
+        <div class="mb-3">
+          <label for="typeOfPlace" class="form-label">Type of place</label>
+          <select class="form-select" id="typeOfPlace" name="listing[typeOfPlace]" required>
+            <option value="entire-place" <%= listing.typeOfPlace === 'entire-place' ? 'selected' : '' %>>Entire Place</option>
+            <option value="room" <%= listing.typeOfPlace === 'room' ? 'selected' : '' %>>Room</option>
+            <option value="shared-room" <%= listing.typeOfPlace === 'shared-room' ? 'selected' : '' %>>Shared Room</option>
+          </select>
+        </div>
+
+        <div class="wizard-row">
+          <div class="mb-3">
+            <label for="maxGuests" class="form-label">Max guests</label>
+            <input type="number" class="form-control" id="maxGuests" name="listing[maxGuests]" min="1" max="16" value="<%= listing.maxGuests || 2 %>" required />
+          </div>
+          <div class="mb-3">
+            <label for="bedrooms" class="form-label">Bedrooms</label>
+            <input type="number" class="form-control" id="bedrooms" name="listing[bedrooms]" min="1" max="8" value="<%= listing.bedrooms %>" required />
+          </div>
+        </div>
+
+        <div class="wizard-row">
+          <div class="mb-3">
+            <label for="beds" class="form-label">Beds</label>
+            <input type="number" class="form-control" id="beds" name="listing[beds]" min="1" max="8" value="<%= listing.beds %>" required />
+          </div>
+          <div class="mb-3">
+            <label for="bathrooms" class="form-label">Bathrooms</label>
+            <input type="number" class="form-control" id="bathrooms" name="listing[bathrooms]" min="1" max="8" value="<%= listing.bathrooms || '' %>" />
+          </div>
+        </div>
+
+        <div class="wizard-row">
+          <div class="mb-3">
+            <label for="locked" class="form-label">Room Locked</label>
+            <select class="form-select" id="locked" name="listing[locked]" required>
+              <option value="yes" <%= listing.locked === 'yes' ? 'selected' : '' %>>Yes</option>
+              <option value="no" <%= listing.locked === 'no' ? 'selected' : '' %>>No</option>
+            </select>
+          </div>
+          <div class="mb-3">
+            <label for="other" class="form-label">Anyone else?</label>
+            <select class="form-select" id="other" name="listing[other]" required>
+              <option value="no" <%= listing.other === 'no' ? 'selected' : '' %>>No</option>
+              <option value="me" <%= listing.other === 'me' ? 'selected' : '' %>>Me</option>
+              <option value="family" <%= listing.other === 'family' ? 'selected' : '' %>>Family</option>
+              <option value="other-guests" <%= listing.other === 'other-guests' ? 'selected' : '' %>>Other Guests</option>
+            </select>
+          </div>
+        </div>
+      </section>
+
+      <!-- Step 2: Location -->
+      <section class="wizard-step" data-step="2">
+        <h4>Where is it?</h4>
+        <p class="wizard-hint">Update the location.</p>
+        <div class="mb-3">
+          <label for="location" class="form-label">Location</label>
+          <input type="text" class="form-control" id="location" name="listing[location]" value="<%= listing.location %>" required />
+        </div>
+        <div class="mb-3">
+          <label for="country" class="form-label">Country</label>
+          <input type="text" class="form-control" id="country" name="listing[country]" value="<%= listing.country %>" required />
+        </div>
+      </section>
+
+      <!-- Step 3: Amenities -->
+      <section class="wizard-step" data-step="3">
+        <h4>Amenities</h4>
+        <p class="wizard-hint">Update what your place offers.</p>
+        <div class="amenity-grid">
+          <% AMENITIES.forEach((amenity, i) => { %>
+            <label class="amenity-item">
+              <input type="checkbox" name="listing[amenities][]" value="<%= amenity %>" id="amenity-<%= i %>" <%= existingAmenities.includes(amenity) ? 'checked' : '' %> />
+              <span class="amenity-tile">
+                <i class="fa-solid fa-check" aria-hidden="true" style="opacity:0.7;"></i>
+                <%= amenity %>
+              </span>
+            </label>
+          <% }); %>
+        </div>
+      </section>
+
+      <!-- Step 4: Photos -->
+      <section class="wizard-step" data-step="4">
+        <h4>Cover photo</h4>
+        <p class="wizard-hint">Upload a new image, or keep the existing one.</p>
+        <% if (typeof originalImageUrl !== 'undefined' && originalImageUrl) { %>
+          <div class="mb-3 text-center">
+            <img src="<%= originalImageUrl %>" alt="Current image" style="max-width:200px; border-radius:0.85rem;" />
+            <div style="font-size:0.85rem; color:#777; margin-top:0.25rem;">Current image</div>
+          </div>
+        <% } %>
+        <label class="upload-zone" for="file">
+          <div style="font-size:2rem; color:#fe424d;">
+            <i class="fa-solid fa-cloud-arrow-up"></i>
+          </div>
+          <div class="upload-text" data-upload-text>Click to upload a new image</div>
+          <input type="file" id="file" name="listing[image]" accept="image/*" />
+        </label>
+      </section>
+
+      <!-- Step 5: Title, description, price, category -->
+      <section class="wizard-step" data-step="5">
+        <h4>Final details</h4>
+        <p class="wizard-hint">Update the listing's title, description and price.</p>
+        <div class="mb-3">
+          <label for="title" class="form-label">Title</label>
+          <input type="text" class="form-control" id="title" name="listing[title]" value="<%= listing.title %>" required />
+        </div>
+        <div class="mb-3">
+          <label for="description" class="form-label">Description</label>
+          <textarea class="form-control" id="description" name="listing[description]" rows="4" required><%= listing.description %></textarea>
+        </div>
+        <div class="wizard-row">
+          <div class="mb-3">
+            <label for="price" class="form-label">Price (per night)</label>
+            <input type="number" class="form-control" id="price" name="listing[price]" min="0" value="<%= listing.price %>" required />
+          </div>
+          <div class="mb-3">
+            <label for="category" class="form-label">Category</label>
+            <select class="form-select" id="category" name="listing[category]" required>
+              <% CATEGORIES.forEach(cat => { %>
+                <option value="<%= cat %>" <%= listing.category === cat ? 'selected' : '' %>><%= cat.charAt(0).toUpperCase() + cat.slice(1) %></option>
+              <% }); %>
+            </select>
+          </div>
+        </div>
+      </section>
+
+      <div class="wizard-actions">
+        <button type="button" class="wizard-btn" data-wizard-back>Back</button>
+        <div>
+          <button type="button" class="wizard-btn wizard-btn-primary" data-wizard-next>Next</button>
+          <button type="submit" class="wizard-btn wizard-btn-primary" data-wizard-submit style="display:none;">Save changes</button>
+        </div>
+      </div>
+    </form>
   </div>
 </body>
-<script>
-  document.getElementById('file').addEventListener('change', function() {
-    var span = document.getElementById('uploadText');
-    if (this.files && this.files.length > 0) {
-      span.textContent = 'New Image Uploaded Successfully';
-      span.style.color="#4BB543";
-      span.style.fontWeight=600;
-    }
-  });
-</script>
+
+<script src="/JS/wizard.js"></script>

--- a/views/listings/new.ejs
+++ b/views/listings/new.ejs
@@ -1,211 +1,169 @@
 <% layout("layouts/boilerplate") -%>
 <link rel="stylesheet" href="/css/new.css" />
+<link rel="stylesheet" href="/css/wizard.css" />
+
+<%
+  const AMENITIES = ['Wifi','Kitchen','Parking','Pool','AC','Heating','Washer','Hot tub','Workspace','BBQ','Beachfront','Pet-friendly'];
+  const CATEGORIES = ['trending','beach','arctic','outside','iconic-city','castles','pool','camping','cabin','farms','mountain','domes','boats','tropical','windmill','ski','chef','disabled','play'];
+%>
+
 <body>
-  <div class="row mt-3">
-    <div class="col-12 col-md-8 offset-md-2">
-      <h3>Create New Listing</h3>
-      <form
-        method="POST"
-        action="/listings"
-        novalidate
-        class="needs-validation"
-        enctype="multipart/form-data"
-        data-validate-form
-      >
-        <div class="mb-3">
-          <label for="title" class="form-label">Title : </label>
-          <input
-            type="text"
-            class="form-control"
-            id="title"
-            name="listing[title]"
-            placeholder="Listing Title"
-            required
-          />
-          <div class="valid-feedback">Title looks Good</div>
-        </div>
-        <div class="mb-3">
-          <label for="description" class="form-label">Description : </label>
-          <textarea
-            type="text"
-            class="form-control"
-            id="description"
-            name="listing[description]"
-            required
-          ></textarea
-          >
-          <div class="invalid-feedback">Please enter a short description</div>
-        </div>
-        
-        <div class="mb-3">
-          <label class="custum-file-upload" for="file">
-            <div class="icon">
-            <svg xmlns="http://www.w3.org/2000/svg" fill="" viewBox="0 0 24 24"><g stroke-width="0" id="SVGRepo_bgCarrier"></g><g stroke-linejoin="round" stroke-linecap="round" id="SVGRepo_tracerCarrier"></g><g id="SVGRepo_iconCarrier"> <path fill="" d="M10 1C9.73478 1 9.48043 1.10536 9.29289 1.29289L3.29289 7.29289C3.10536 7.48043 3 7.73478 3 8V20C3 21.6569 4.34315 23 6 23H7C7.55228 23 8 22.5523 8 22C8 21.4477 7.55228 21 7 21H6C5.44772 21 5 20.5523 5 20V9H10C10.5523 9 11 8.55228 11 8V3H18C18.5523 3 19 3.44772 19 4V9C19 9.55228 19.4477 10 20 10C20.5523 10 21 9.55228 21 9V4C21 2.34315 19.6569 1 18 1H10ZM9 7H6.41421L9 4.41421V7ZM14 15.5C14 14.1193 15.1193 13 16.5 13C17.8807 13 19 14.1193 19 15.5V16V17H20C21.1046 17 22 17.8954 22 19C22 20.1046 21.1046 21 20 21H13C11.8954 21 11 20.1046 11 19C11 17.8954 11.8954 17 13 17H14V16V15.5ZM16.5 11C14.142 11 12.2076 12.8136 12.0156 15.122C10.2825 15.5606 9 17.1305 9 19C9 21.2091 10.7909 23 13 23H20C22.2091 23 24 21.2091 24 19C24 17.1305 22.7175 15.5606 20.9844 15.122C20.7924 12.8136 18.858 11 16.5 11Z" clip-rule="evenodd" fill-rule="evenodd"></path> </g></svg>
-            </div>
-            <div class="text">
-               <span id="uploadText">Click to upload image</span>
-               </div>
-               <input type="file" id="file" name="listing[image]" class="form-control">
-            </label>
-            
-        </div>
-       
-
-        <div class="row">
-          <div class="mb-3 col-md-8">
-            <label for="price" class="form-label">Price : </label>
-            <input
-              type="number"
-              class="form-control"
-              id="price"
-              name="listing[price]"
-              placeholder="1200"
-              required
-            />
-            <div class="invalid-feedback">Price should be valid</div>
-          </div>
-          <div class="mb-2 col-md-4">
-            <label for="select-styling" id="label">Catogery :</label>
-          <select
-            class="custom-select form-select"
-            id="select-styling"
-            placeholder="Choose"
-            name="listing[category]"
-            required
-          >
-          <option value="trending">Trending</option>
-              <option value="beach">Beach</option>
-              <option value="arctic">Arctic</option>
-              <option value="outside">Outside</option>
-              <option value="iconic-city">Iconic City</option>
-              <option value="castles">Castles</option>
-              <option value="pool">Pool</option>
-              <option value="camping">Camping</option>
-              <option value="cabin">Cabin</option>
-              <option value="farms">Farms</option>
-              <option value="mountain">Mountain</option>
-              <option value="domes">Domes</option>
-              <option value="boats">Boats</option>
-              <option value="tropical">Tropical</option>
-              <option value="windmill">Windmill</option>
-              <option value="ski">Ski</option>
-              <option value="chef">Chef</option>
-              <option value="disabled">Disabled</option>
-              <option value="play">Play</option>
-
-       
-          </select>
-          </div>
-        </div>
-        <div class="row">
-          <div class="mb-3 col-md-4">
-            <label for="location" class="form-label">Location : </label>
-            <input
-              type="text"
-              class="form-control"
-              id="location"
-              name="listing[location]"
-              placeholder="Indore,Madhya Pradesh"
-              required
-            />
-            <div class="invalid-feedback">Location should be valid</div>
-          </div>
-          <div class="col-md-8 mb-3 select-label">
-            <label for="country" class="form-label">Country : </label>
-              <input
-                type="text"
-                class="form-control"
-                id="country"
-                name="listing[country]"
-                placeholder="India"
-                required
-              />
-              <div class="invalid-feedback">Country name should be valid</div>
-          </div>
-  
-        </div>
- <!-- Bedrooms and Beds -->
-       <div class="row mb-3">
-        <div class="col-md-6">
-          <label for="bedrooms" class="form-label">Bedrooms:</label>
-        <input type="number" id="bedrooms" name="listing[bedrooms]"  class="form-control" min="1" max="8" required />
-        </div>
-
-       <div class="col-md-6">
-        <label for="beds" class="form-label">Beds:</label>
-        <input type="number" id="beds" name="listing[beds]"  class="form-control" required min="1" max="8"/>
-       </div>
-       </div>
-
-       <div class="row">
-        <div class="col-md-4">
-          <label for="select-styling" id="label">Type Of Place :</label>
-        <select
-          class="custom-select form-select"
-          id="select-styling"
-          placeholder="Choose"
-          name="listing[typeOfPlace]"
-          class="form-control"
-        >
-        <option value="entire-place">Entire Place</option>
-        <option value="room">Room</option>
-        <option value="shared-room">Shared Room</option>
-
-        </select>
-        </div>
-       
-
-        <div class="col-md-4">
-          <label for="room-locked" id="label">Room Locked :</label>
-        <select
-          class="custom-select form-select"
-          id="room-locked"
-          placeholder="Choose"
-          name="listing[locked]"
-          class="form-control"
-        >
-        <option value="yes">Yes</option>
-          <option value="no">No</option>
-
-        </select>
-        </div>
-
-      <div class="col-md-4">
-        <label for="someone" id="label">Is There Someone Else :</label>
-        <select
-          class="custom-select form-select"
-          id="someone"
-          placeholder="Choose"
-          name="listing[other]"
-          class="form-control"
-        >
-        <option value="no">No</option>
-        <option value="me">Me</option>
-        <option value="family">Family</option>
-        <option value="other-guests">Other Guest</option>
-
-        </select>
-      </div>
-       </div>
-      </div>
-      </div>
-     
-        <button class="btn offset-md-2 edit-button mt-2 mb-3"><span>Submit</span></button>
-      </form>
-      <br>
-      <br>
-      <br>
-      <br>
+  <div class="wizard" data-wizard>
+    <h3 class="text-center mb-1">Create New Listing</h3>
+    <div class="wizard-step-counter">Step 1 of 5</div>
+    <div class="wizard-progress" aria-hidden="true">
+      <span class="wizard-dot"></span>
+      <span class="wizard-dot"></span>
+      <span class="wizard-dot"></span>
+      <span class="wizard-dot"></span>
+      <span class="wizard-dot"></span>
     </div>
+
+    <form
+      method="POST"
+      action="/listings"
+      novalidate
+      class="needs-validation"
+      enctype="multipart/form-data"
+      data-validate-form
+    >
+      <!-- Step 1: Place type & basics -->
+      <section class="wizard-step" data-step="1" data-active>
+        <h4>About your place</h4>
+        <p class="wizard-hint">Tell us the basics — type, capacity, layout.</p>
+
+        <div class="mb-3">
+          <label for="typeOfPlace" class="form-label">Type of place</label>
+          <select class="form-select" id="typeOfPlace" name="listing[typeOfPlace]" required>
+            <option value="entire-place">Entire Place</option>
+            <option value="room">Room</option>
+            <option value="shared-room">Shared Room</option>
+          </select>
+        </div>
+
+        <div class="wizard-row">
+          <div class="mb-3">
+            <label for="maxGuests" class="form-label">Max guests</label>
+            <input type="number" class="form-control" id="maxGuests" name="listing[maxGuests]" min="1" max="16" value="2" required />
+          </div>
+          <div class="mb-3">
+            <label for="bedrooms" class="form-label">Bedrooms</label>
+            <input type="number" class="form-control" id="bedrooms" name="listing[bedrooms]" min="1" max="8" required />
+          </div>
+        </div>
+
+        <div class="wizard-row">
+          <div class="mb-3">
+            <label for="beds" class="form-label">Beds</label>
+            <input type="number" class="form-control" id="beds" name="listing[beds]" min="1" max="8" required />
+          </div>
+          <div class="mb-3">
+            <label for="bathrooms" class="form-label">Bathrooms</label>
+            <input type="number" class="form-control" id="bathrooms" name="listing[bathrooms]" min="1" max="8" />
+          </div>
+        </div>
+
+        <div class="wizard-row">
+          <div class="mb-3">
+            <label for="locked" class="form-label">Room Locked</label>
+            <select class="form-select" id="locked" name="listing[locked]" required>
+              <option value="yes">Yes</option>
+              <option value="no">No</option>
+            </select>
+          </div>
+          <div class="mb-3">
+            <label for="other" class="form-label">Anyone else?</label>
+            <select class="form-select" id="other" name="listing[other]" required>
+              <option value="no">No</option>
+              <option value="me">Me</option>
+              <option value="family">Family</option>
+              <option value="other-guests">Other Guests</option>
+            </select>
+          </div>
+        </div>
+      </section>
+
+      <!-- Step 2: Location -->
+      <section class="wizard-step" data-step="2">
+        <h4>Where is it?</h4>
+        <p class="wizard-hint">Tell guests where they'll stay.</p>
+        <div class="mb-3">
+          <label for="location" class="form-label">Location</label>
+          <input type="text" class="form-control" id="location" name="listing[location]" placeholder="Indore, Madhya Pradesh" required />
+        </div>
+        <div class="mb-3">
+          <label for="country" class="form-label">Country</label>
+          <input type="text" class="form-control" id="country" name="listing[country]" placeholder="India" required />
+        </div>
+      </section>
+
+      <!-- Step 3: Amenities -->
+      <section class="wizard-step" data-step="3">
+        <h4>Amenities</h4>
+        <p class="wizard-hint">Pick what your place offers.</p>
+        <div class="amenity-grid">
+          <% AMENITIES.forEach((amenity, i) => { %>
+            <label class="amenity-item">
+              <input type="checkbox" name="listing[amenities][]" value="<%= amenity %>" id="amenity-<%= i %>" />
+              <span class="amenity-tile">
+                <i class="fa-solid fa-check" aria-hidden="true" style="opacity:0.7;"></i>
+                <%= amenity %>
+              </span>
+            </label>
+          <% }); %>
+        </div>
+      </section>
+
+      <!-- Step 4: Photos -->
+      <section class="wizard-step" data-step="4">
+        <h4>Add a cover photo</h4>
+        <p class="wizard-hint">One striking shot helps guests decide.</p>
+        <label class="upload-zone" for="file">
+          <div style="font-size:2rem; color:#fe424d;">
+            <i class="fa-solid fa-cloud-arrow-up"></i>
+          </div>
+          <div class="upload-text" data-upload-text>Click to upload image</div>
+          <input type="file" id="file" name="listing[image]" accept="image/*" required />
+        </label>
+      </section>
+
+      <!-- Step 5: Title, description, price, category -->
+      <section class="wizard-step" data-step="5">
+        <h4>Final details</h4>
+        <p class="wizard-hint">Give it a name, story, and price.</p>
+        <div class="mb-3">
+          <label for="title" class="form-label">Title</label>
+          <input type="text" class="form-control" id="title" name="listing[title]" placeholder="Listing Title" required />
+        </div>
+        <div class="mb-3">
+          <label for="description" class="form-label">Description</label>
+          <textarea class="form-control" id="description" name="listing[description]" rows="4" required></textarea>
+        </div>
+        <div class="wizard-row">
+          <div class="mb-3">
+            <label for="price" class="form-label">Price (per night)</label>
+            <input type="number" class="form-control" id="price" name="listing[price]" placeholder="1200" min="0" required />
+          </div>
+          <div class="mb-3">
+            <label for="category" class="form-label">Category</label>
+            <select class="form-select" id="category" name="listing[category]" required>
+              <% CATEGORIES.forEach(cat => { %>
+                <option value="<%= cat %>"><%= cat.charAt(0).toUpperCase() + cat.slice(1) %></option>
+              <% }); %>
+            </select>
+          </div>
+        </div>
+      </section>
+
+      <div class="wizard-actions">
+        <button type="button" class="wizard-btn" data-wizard-back>Back</button>
+        <div>
+          <button type="button" class="wizard-btn wizard-btn-primary" data-wizard-next>Next</button>
+          <button type="submit" class="wizard-btn wizard-btn-primary" data-wizard-submit style="display:none;">Submit</button>
+        </div>
+      </div>
+    </form>
   </div>
 </body>
-<script>
-  document.getElementById('file').addEventListener('change', function() {
-    var span = document.getElementById('uploadText');
-    if (this.files && this.files.length > 0) {
-      span.textContent = 'Image Uploaded Successfully';
-      span.style.color="#4BB543";
-      span.style.fontWeight=600;
-    }
-  });
-</script>
+
+<script src="/JS/wizard.js"></script>


### PR DESCRIPTION
Closes #15

## Summary
- Adds 5-step Airbnb-style wizard for both creating and editing listings.
- Steps: 1) Place type & basics (typeOfPlace, maxGuests, bedrooms, beds, bathrooms), 2) Location, 3) Amenities (multi-checkbox grid), 4) Cover photo, 5) Title/description/price/category.
- Next button is gated by HTML5 checkValidity() of required fields on the current step. Back returns to previous step. Progress dots at the top.
- Final step submits the existing POST /listings / PUT /listings/:id routes with the same req.body.listing[...] shape, plus three new optional fields.

## Changes
- models/listing.js: adds bathrooms (max 8), maxGuests (max 16, default 2), amenities: [String].
- schema.js: allows the new fields (optional, backwards compatible).
- controller/listings.js: persists bathrooms, maxGuests, amenities on create/update; trims empty amenity strings.
- views/listings/new.ejs and editForm.ejs: rewritten as wizard sections.
- public/css/wizard.css + public/JS/wizard.js: new files (existing CSS untouched).

## Test plan
- [ ] Walking through all 5 steps creates a listing successfully.
- [ ] Opening edit on an existing listing pre-fills every step (including amenity checkboxes).
- [ ] Next button stays disabled until current step validates; Back returns to previous step.
- [ ] Submitting on step 5 triggers the form's normal POST.