### PR TITLE
feat: illustrations + lottie animations for empty states & hero

### DIFF
--- a/public/Assets/illustrations/empty-cart.svg
+++ b/public/Assets/illustrations/empty-cart.svg
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 480 360" role="img" aria-label="Empty wishlist illustration">
+  <defs>
+    <linearGradient id="ec-grad" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#fe424d"/>
+      <stop offset="100%" stop-color="#ff7b88"/>
+    </linearGradient>
+  </defs>
+  <ellipse cx="240" cy="320" rx="170" ry="14" fill="#fe424d" opacity="0.12"/>
+  <g transform="translate(140 80)">
+    <path d="M10 40 L40 40 L70 200 L210 200 L240 90 L70 90"
+          fill="none" stroke="#fe424d" stroke-width="6"
+          stroke-linecap="round" stroke-linejoin="round"/>
+    <circle cx="100" cy="230" r="14" fill="url(#ec-grad)"/>
+    <circle cx="190" cy="230" r="14" fill="url(#ec-grad)"/>
+  </g>
+  <g transform="translate(220 130)" fill="#fe424d">
+    <path d="M30 18 a16 16 0 0 1 28-10 a16 16 0 0 1 28 10 c0 18 -28 36 -28 36 s-28 -18 -28 -36 z" opacity="0.85"/>
+  </g>
+  <g fill="#fe424d" opacity="0.5">
+    <circle cx="80" cy="110" r="4"/>
+    <circle cx="400" cy="90" r="3"/>
+    <circle cx="420" cy="200" r="5"/>
+    <circle cx="60" cy="240" r="3"/>
+  </g>
+</svg>

--- a/public/Assets/illustrations/house-searching.svg
+++ b/public/Assets/illustrations/house-searching.svg
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 480 360" role="img" aria-label="No results found illustration">
+  <defs>
+    <linearGradient id="hs-red" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#fe424d"/>
+      <stop offset="100%" stop-color="#ff7b88"/>
+    </linearGradient>
+  </defs>
+  <ellipse cx="240" cy="320" rx="170" ry="14" fill="#fe424d" opacity="0.12"/>
+  <!-- house -->
+  <g transform="translate(140 110)">
+    <path d="M0 80 L100 0 L200 80 L200 200 L0 200 Z" fill="url(#hs-red)" opacity="0.92"/>
+    <rect x="40" y="120" width="50" height="80" fill="#fff" opacity="0.85"/>
+    <rect x="120" y="100" width="50" height="40" fill="#fff" opacity="0.85"/>
+    <path d="M0 80 L100 0 L200 80" fill="none" stroke="#fff" stroke-width="3" opacity="0.6"/>
+  </g>
+  <!-- magnifier -->
+  <g transform="translate(290 200)">
+    <circle cx="0" cy="0" r="48" fill="none" stroke="#fe424d" stroke-width="8"/>
+    <circle cx="0" cy="0" r="38" fill="#fff" opacity="0.55"/>
+    <line x1="34" y1="34" x2="78" y2="78" stroke="#fe424d" stroke-width="10" stroke-linecap="round"/>
+  </g>
+  <g fill="#fe424d" opacity="0.5">
+    <circle cx="60" cy="80" r="3"/>
+    <circle cx="420" cy="60" r="4"/>
+    <circle cx="420" cy="240" r="3"/>
+  </g>
+</svg>

--- a/public/Assets/illustrations/journey.svg
+++ b/public/Assets/illustrations/journey.svg
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 400" role="img" aria-label="Travel journey illustration">
+  <defs>
+    <linearGradient id="j-sky" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#fff0f1"/>
+      <stop offset="100%" stop-color="#ffe1e3"/>
+    </linearGradient>
+    <linearGradient id="j-red" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#fe424d"/>
+      <stop offset="100%" stop-color="#ff7b88"/>
+    </linearGradient>
+  </defs>
+  <rect width="600" height="400" fill="url(#j-sky)"/>
+  <ellipse cx="300" cy="370" rx="240" ry="18" fill="#fe424d" opacity="0.08"/>
+  <!-- mountains -->
+  <path d="M0 320 L120 200 L210 280 L320 160 L450 290 L600 220 L600 400 L0 400 Z"
+        fill="#fe424d" opacity="0.18"/>
+  <path d="M0 340 L90 260 L170 320 L280 230 L400 320 L520 270 L600 310 L600 400 L0 400 Z"
+        fill="#fe424d" opacity="0.32"/>
+  <!-- sun -->
+  <circle cx="470" cy="120" r="42" fill="url(#j-red)"/>
+  <!-- airplane -->
+  <g transform="translate(150 110) rotate(-15)" fill="#fe424d">
+    <path d="M0 20 L80 4 L100 0 L84 18 L120 24 L84 32 L100 50 L80 46 L0 30 Z"/>
+  </g>
+  <!-- dotted path -->
+  <g stroke="#fe424d" stroke-width="3" stroke-dasharray="2 8" stroke-linecap="round" fill="none">
+    <path d="M180 140 Q280 220 360 180 T540 200"/>
+  </g>
+  <!-- pin -->
+  <g transform="translate(528 168)">
+    <path d="M0 0 a14 14 0 1 1 0.01 0 z M-14 0 c0 16 14 32 14 32 s14 -16 14 -32"
+          fill="url(#j-red)"/>
+    <circle cx="0" cy="0" r="5" fill="#fff"/>
+  </g>
+</svg>

--- a/public/Assets/illustrations/not-found.svg
+++ b/public/Assets/illustrations/not-found.svg
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 400" role="img" aria-label="Page not found illustration">
+  <defs>
+    <linearGradient id="nf-red" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#fe424d"/>
+      <stop offset="100%" stop-color="#ff7b88"/>
+    </linearGradient>
+  </defs>
+  <ellipse cx="300" cy="360" rx="220" ry="16" fill="#fe424d" opacity="0.1"/>
+  <!-- 404 text -->
+  <g font-family="'Plus Jakarta Sans', system-ui, sans-serif" font-weight="800"
+     text-anchor="middle" fill="url(#nf-red)">
+    <text x="300" y="200" font-size="160" letter-spacing="-4">404</text>
+  </g>
+  <!-- compass -->
+  <g transform="translate(300 260)">
+    <circle r="34" fill="none" stroke="#fe424d" stroke-width="4"/>
+    <polygon points="0,-22 6,0 0,22 -6,0" fill="#fe424d"/>
+    <circle r="3" fill="#fff"/>
+  </g>
+  <!-- floating dots -->
+  <g fill="#fe424d" opacity="0.5">
+    <circle cx="100" cy="120" r="5"/>
+    <circle cx="500" cy="100" r="4"/>
+    <circle cx="80" cy="280" r="3"/>
+    <circle cx="520" cy="280" r="5"/>
+    <circle cx="180" cy="60" r="3"/>
+    <circle cx="420" cy="320" r="3"/>
+  </g>
+</svg>

--- a/public/Assets/illustrations/welcome.svg
+++ b/public/Assets/illustrations/welcome.svg
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 480 480" role="img" aria-label="Welcome to WanderLust illustration">
+  <defs>
+    <linearGradient id="w-red" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#fe424d"/>
+      <stop offset="100%" stop-color="#ff7b88"/>
+    </linearGradient>
+    <radialGradient id="w-glow" cx="0.5" cy="0.5" r="0.5">
+      <stop offset="0%" stop-color="#fe424d" stop-opacity="0.18"/>
+      <stop offset="100%" stop-color="#fe424d" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+  <circle cx="240" cy="240" r="220" fill="url(#w-glow)"/>
+  <!-- envelope -->
+  <g transform="translate(100 160)">
+    <rect x="0" y="0" width="280" height="180" rx="14" fill="url(#w-red)"/>
+    <path d="M0 14 L140 110 L280 14" fill="none" stroke="#fff" stroke-width="6" stroke-linejoin="round"/>
+    <path d="M0 180 L120 100 M280 180 L160 100" stroke="#fff" stroke-width="3" opacity="0.6"/>
+  </g>
+  <!-- heart -->
+  <g transform="translate(220 220)">
+    <path d="M0 18 a18 18 0 0 1 36 -10 a18 18 0 0 1 36 10 c0 22 -36 44 -36 44 s-36 -22 -36 -44 z"
+          fill="#fff" stroke="#fe424d" stroke-width="3"/>
+  </g>
+  <!-- sparkles -->
+  <g fill="#fe424d">
+    <path d="M80 100 l4 12 l12 4 l-12 4 l-4 12 l-4 -12 l-12 -4 l12 -4 z"/>
+    <path d="M400 120 l3 9 l9 3 l-9 3 l-3 9 l-3 -9 l-9 -3 l9 -3 z"/>
+    <path d="M120 380 l3 9 l9 3 l-9 3 l-3 9 l-3 -9 l-9 -3 l9 -3 z" opacity="0.7"/>
+    <path d="M380 360 l4 12 l12 4 l-12 4 l-4 12 l-4 -12 l-12 -4 l12 -4 z" opacity="0.7"/>
+  </g>
+</svg>

--- a/public/css/illustrations.css
+++ b/public/css/illustrations.css
@@ -1,0 +1,104 @@
+/* illustrations.css — sizing & layout for unDraw-style brand-tinted SVGs */
+/* Layered file: do not edit existing CSS, this overrides as needed. */
+
+.wl-illus {
+  display: block;
+  width: 100%;
+  height: auto;
+  max-width: 100%;
+  user-select: none;
+  -webkit-user-drag: none;
+}
+
+/* Empty / message states */
+.wl-empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 2.5rem 1rem;
+  gap: 1rem;
+  min-height: 50vh;
+}
+
+.wl-empty-state .wl-illus {
+  max-width: 320px;
+  margin-inline: auto;
+}
+
+.wl-empty-state__title {
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin: 0;
+  color: #fe424d;
+}
+
+.wl-empty-state__caption {
+  font-size: 1rem;
+  opacity: 0.78;
+  max-width: 36ch;
+  margin: 0;
+}
+
+.wl-empty-state .btn,
+.wl-empty-state .wl-back-btn {
+  margin-top: 0.5rem;
+  background: #fe424d;
+  color: #fff;
+  border: 0;
+  padding: 0.65rem 1.25rem;
+  border-radius: 999px;
+  font-weight: 600;
+  text-decoration: none;
+  display: inline-block;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.wl-empty-state .btn:hover,
+.wl-empty-state .wl-back-btn:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 6px 18px rgba(254, 66, 77, 0.28);
+  color: #fff;
+}
+
+/* 404 page */
+.wl-error-page {
+  min-height: 60vh;
+}
+.wl-error-page .wl-illus {
+  max-width: 460px;
+}
+
+/* Signup two-column with illustration */
+.wl-signup-illus-col {
+  display: none; /* hidden on mobile */
+  align-items: center;
+  justify-content: center;
+  padding: 2rem 1rem;
+}
+.wl-signup-illus-col .wl-illus {
+  max-width: 420px;
+}
+
+@media (min-width: 768px) {
+  .wl-signup-illus-col {
+    display: flex;
+  }
+}
+
+/* Hero illustration */
+.wl-hero-illus {
+  max-width: 540px;
+  margin-inline: auto;
+}
+
+/* Lazy / dimensioned images: prevent CLS via aspect-ratio */
+img.wl-illus {
+  aspect-ratio: attr(width) / attr(height);
+}
+
+/* Reduced motion: nothing to do here, but keep illustrations static */
+@media (prefers-reduced-motion: reduce) {
+  .wl-illus { transition: none; }
+}

--- a/views/layouts/boilerplate.ejs
+++ b/views/layouts/boilerplate.ejs
@@ -52,6 +52,7 @@
     <link rel="stylesheet" href="/css/header-scroll.css" />
     <link rel="stylesheet" href="/css/form-validate.css" />
     <link rel="stylesheet" href="/css/search-autocomplete.css" />
+    <link rel="stylesheet" href="/css/illustrations.css" />
     <link
       href="https://api.mapbox.com/mapbox-gl-js/v3.3.0/mapbox-gl.css" rel="stylesheet"/>
     <script src="https://api.mapbox.com/mapbox-gl-js/v3.3.0/mapbox-gl.js"></script>

--- a/views/listings/error.ejs
+++ b/views/listings/error.ejs
@@ -1,9 +1,19 @@
 <% layout("layouts/boilerplate") -%>
 
 <body>
-  <div class="row mt-3">
-    <div class="alert alert-danger col-6 offset-3" role="alert">
-      <p><%= err.message %></p>
-    </div>
+  <div class="wl-empty-state wl-error-page" role="alert" aria-live="polite">
+    <img
+      src="/Assets/illustrations/not-found.svg"
+      alt="Page not found"
+      class="wl-illus"
+      loading="lazy"
+      width="600"
+      height="400"
+    />
+    <h1 class="wl-empty-state__title">We couldn't find that page</h1>
+    <p class="wl-empty-state__caption">
+      <%= (typeof err !== 'undefined' && err && err.message) ? err.message : "The page you're looking for has wandered off." %>
+    </p>
+    <a href="/listings" class="wl-back-btn">Back to listings</a>
   </div>
 </body>

--- a/views/users/signup.ejs
+++ b/views/users/signup.ejs
@@ -13,8 +13,18 @@
   }
 </style>
 
-<div class="row mt-3">
-  <div class="col-12 col-md-6 offset-md-3 mb-4">
+<div class="row mt-3 align-items-center">
+  <div class="col-md-6 wl-signup-illus-col d-none d-md-flex">
+    <img
+      src="/Assets/illustrations/welcome.svg"
+      alt="Welcome to WanderLust"
+      class="wl-illus"
+      loading="lazy"
+      width="480"
+      height="480"
+    />
+  </div>
+  <div class="col-12 col-md-6 mb-4">
     <h2 class="mb-4" id="form-head">Join WanderLust Today</h2>
     <form action="/signup" method="POST" novalidate class="needs-validation" data-validate-form>
       <div class="form-floating mb-4">

--- a/views/users/wishlists.ejs
+++ b/views/users/wishlists.ejs
@@ -55,7 +55,21 @@
   <% }); %>
 </div>
 <% } else { %>
-<p>No items in your wishlist.</p>
+<div class="wl-empty-state" aria-live="polite">
+  <img
+    src="/Assets/illustrations/empty-cart.svg"
+    alt="Empty wishlist"
+    class="wl-illus"
+    loading="lazy"
+    width="480"
+    height="360"
+  />
+  <h2 class="wl-empty-state__title">Save listings you love</h2>
+  <p class="wl-empty-state__caption">
+    Tap the heart on any listing to add it here. Your favorites will live in your wishlist.
+  </p>
+  <a href="/listings" class="wl-back-btn">Browse listings</a>
+</div>
 <% } %>
 
 <script src="/JS/index.js"></script>


### PR DESCRIPTION
Closes #17

## Summary
- Adds a small set of brand-tinted SVG illustrations under `public/Assets/illustrations/` (empty-cart, journey, house-searching, not-found, welcome) and integrates them across empty states and the signup page.
- New layered stylesheet `public/css/illustrations.css` (existing CSS untouched) provides responsive sizing and an accessible empty-state pattern. Linked from `views/layouts/boilerplate.ejs`.
- All illustrations use brand red `#fe424d` (and the gradient pinks) as the dominant fill so they fit the existing palette.

## Notes on assets
- External downloads from unDraw and LottieFiles were unreachable from this environment (sandbox blocked outbound network on the second attempt as well). Per the task fallback, the SVGs in this PR are inline brand-tinted placeholders so the integration ships intact — they are easy to swap later with the equivalent unDraw originals (`empty-cart`, `journey`, `house-searching`, `not-found`, `welcome`) without touching markup or CSS.
- Lottie was skipped per the spec's fallback ("If the download fails, skip Lottie and proceed with just illustrations.").
- Every `<img>` has `loading="lazy"` plus explicit `width`/`height` attributes to avoid CLS.

## Integrations
- `views/listings/error.ejs` — 404/error surface uses `not-found.svg` with caption + "Back to listings" CTA.
- `views/users/wishlists.ejs` — empty branch now uses `empty-cart.svg` + "Save listings you love" copy.
- `views/users/signup.ejs` — desktop-only two-column layout: `welcome.svg` left, form right (Bootstrap `d-none d-md-flex`).
- No `views/landing.ejs` exists in the repo, so the hero illustration was committed for future use but not wired up.

## Test plan
- [ ] Visit a non-existent route (e.g. `/nope`) — 404 page renders the brand-tinted illustration with a "Back to listings" button.
- [ ] Sign in with a user that has no favorites and visit `/wishlists` — empty-cart illustration + "Save listings you love" copy is shown.
- [ ] Visit `/signup` on a >=md viewport — illustration appears on the left column, form on the right; on mobile the illustration column is hidden.
- [ ] Confirm `GET /Assets/illustrations/<name>.svg` returns 200 (Express static).
- [ ] Confirm brand red `#fe424d` and gradient pinks unchanged elsewhere.