### PR TITLE
feat: host profile card on listing show page

### DIFF
--- a/controller/listings.js
+++ b/controller/listings.js
@@ -78,11 +78,20 @@ module.exports.showListing = async (req, res) => {
       }
     }
 
+    // Count of listings owned by this host (for host profile card)
+    let ownerListingsCount = 0;
+    if (listing.owner && listing.owner._id) {
+      ownerListingsCount = await Listing.countDocuments({
+        owner: listing.owner._id,
+      });
+    }
+
     res.render("listings/show.ejs", {
       listing,
       averageRating,
       ratingPercentages,
       currentUser: req.user,
+      ownerListingsCount,
     });
   } catch (error) {
     console.error("Error:", error);

--- a/public/css/host-card.css
+++ b/public/css/host-card.css
@@ -1,0 +1,122 @@
+/* host-card.css — "Hosted by X" profile card on show page
+ * Brand: red #fe424d, gradient pinks, Plus Jakarta Sans, 1rem rounded.
+ */
+
+.host-card {
+  display: flex;
+  gap: 1.1rem;
+  align-items: flex-start;
+  padding: 1.25rem;
+  border: 1px solid #ececec;
+  border-radius: 1rem;
+  background: #fff;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.04);
+  font-family: "Plus Jakarta Sans", sans-serif;
+  margin: 0.5rem 0;
+}
+
+.host-card .host-avatar {
+  flex: 0 0 auto;
+  width: 76px;
+  height: 76px;
+  border-radius: 50%;
+  overflow: hidden;
+  background: linear-gradient(135deg, #fe424d 0%, #ff7a85 100%);
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  font-size: 1.85rem;
+  flex-shrink: 0;
+  box-shadow: 0 4px 14px rgba(254, 66, 77, 0.25);
+}
+
+.host-card .host-avatar img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.host-card .host-body {
+  min-width: 0;
+  flex: 1;
+}
+
+.host-card .host-name {
+  font-size: 1.15rem;
+  font-weight: 700;
+  margin: 0 0 0.15rem;
+  color: #222;
+}
+
+.host-card .host-tagline {
+  font-size: 0.92rem;
+  color: #fe424d;
+  font-weight: 600;
+  margin: 0 0 0.5rem;
+}
+
+.host-card .host-bio {
+  color: #555;
+  font-size: 0.95rem;
+  line-height: 1.5;
+  margin: 0 0 0.75rem;
+}
+
+.host-card .host-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem 1.2rem;
+  font-size: 0.88rem;
+  color: #666;
+}
+
+.host-card .host-meta .meta-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.host-card .host-meta i {
+  color: #fe424d;
+}
+
+.host-card .host-meta strong {
+  color: #222;
+  font-weight: 700;
+}
+
+@media (max-width: 520px) {
+  .host-card {
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+  }
+  .host-card .host-meta {
+    justify-content: center;
+  }
+}
+
+[data-theme="dark"] .host-card {
+  background: #1f1f1f;
+  border-color: #333;
+  box-shadow: 0 4px 18px rgba(0, 0, 0, 0.35);
+}
+
+[data-theme="dark"] .host-card .host-name {
+  color: #f5f5f5;
+}
+
+[data-theme="dark"] .host-card .host-bio {
+  color: #cdcdcd;
+}
+
+[data-theme="dark"] .host-card .host-meta {
+  color: #aaa;
+}
+
+[data-theme="dark"] .host-card .host-meta strong {
+  color: #f0f0f0;
+}

--- a/views/listings/show.ejs
+++ b/views/listings/show.ejs
@@ -1,6 +1,7 @@
 <% layout("layouts/boilerplate") -%>
 <link rel="stylesheet" href="/css/show.css" />
 <link rel="stylesheet" href="/css/index.css" />
+<link rel="stylesheet" href="/css/host-card.css" />
 <style>
   .star {
     font-size: 1rem;
@@ -155,13 +156,47 @@
             <hr>
           <% } %>
 
-          <div class="owner-card">
-            <div class="owner-avatar">
-              <span class="avatar-circle"><%= listing.owner.username.charAt(0).toUpperCase() %></span>
+          <%
+            const _hostOwner = listing.owner || {};
+            const _hostDisplayName = _hostOwner.displayName || _hostOwner.username || "Host";
+            const _hostBio = _hostOwner.bio && String(_hostOwner.bio).trim()
+              ? _hostOwner.bio
+              : "Host on WanderLust";
+            const _hostAvatarUrl = (_hostOwner.avatar && _hostOwner.avatar.url) ? _hostOwner.avatar.url : null;
+            const _hostInitial = (_hostDisplayName || "H").charAt(0).toUpperCase();
+            let _memberSince = "";
+            try {
+              if (_hostOwner._id && typeof _hostOwner._id.getTimestamp === "function") {
+                _memberSince = new Date(_hostOwner._id.getTimestamp())
+                  .toLocaleDateString("en-IN", { month: "long", year: "numeric" });
+              }
+            } catch (e) { _memberSince = ""; }
+            const _ownerListingsCount = (typeof ownerListingsCount !== "undefined") ? ownerListingsCount : 0;
+          %>
+          <div class="host-card" aria-label="Host profile">
+            <div class="host-avatar">
+              <% if (_hostAvatarUrl) { %>
+                <img src="<%= _hostAvatarUrl %>" alt="<%= _hostDisplayName %>" />
+              <% } else { %>
+                <span class="avatar-circle"><%= _hostInitial %></span>
+              <% } %>
             </div>
-            <div class="owner-info">
-              <p class="card-text"><strong>Hosted and owned by:</strong></p>
-              <p class="card-text owner-name"><%= listing.owner.username %></p>
+            <div class="host-body">
+              <p class="host-tagline">Hosted by</p>
+              <h4 class="host-name"><%= _hostDisplayName %></h4>
+              <p class="host-bio"><%= _hostBio %></p>
+              <div class="host-meta">
+                <% if (_memberSince) { %>
+                  <span class="meta-item">
+                    <i class="fa-regular fa-calendar"></i>
+                    Member since <strong><%= _memberSince %></strong>
+                  </span>
+                <% } %>
+                <span class="meta-item">
+                  <i class="fa-solid fa-house"></i>
+                  <strong><%= _ownerListingsCount %></strong> listing<%= _ownerListingsCount === 1 ? '' : 's' %>
+                </span>
+              </div>
             </div>
           </div>
 


### PR DESCRIPTION
Closes #24

## Summary
- Replaces the simple .owner-card on views/listings/show.ejs with a richer "Hosted by X" card.
- Card shows: large circular avatar (avatar.url if set, else initial), displayName || username, bio (fallback "Host on WanderLust"), member-since (from owner._id.getTimestamp(), en-IN long-month/numeric-year), and listings count.
- showListing now passes ownerListingsCount via Listing.countDocuments({ owner: listing.owner._id }).
- New CSS at public/css/host-card.css; existing CSS files untouched.
- Falls back gracefully when avatar/displayName/bio are not set on older user accounts.
- Works in both light and dark themes.

## Test plan
- [ ] Render a listing where owner has displayName + bio + avatar → all show.
- [ ] Render a listing where owner has none → falls back to username + initial avatar; bio shows "Host on WanderLust".
- [ ] Member-since shows month + year using en-IN locale.
- [ ] Listings count matches the host's actual listing total.
- [ ] Card looks correct in light and dark themes.